### PR TITLE
Custom chunk mesh shader and fixed ambient occlusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3311,6 +3311,7 @@ name = "gs_schemas"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "bevy_color",
  "bevy_math",
  "bevy_reflect",
  "bitflags 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,13 @@ features = [
     "serialize", # Support for `serde` Serialize/Deserialize
 ]
 
+[workspace.dependencies.bevy_color]
+version = "0.15.0"
+default-features = false
+features = [
+    "serialize", # Support for `serde` Serialize/Deserialize
+]
+
 [workspace.dependencies.bevy_reflect]
 version = "0.15.0"
 features = ["smallvec", "glam", "uuid"]

--- a/assets/shaders/chunk_mesh_main.wgsl
+++ b/assets/shaders/chunk_mesh_main.wgsl
@@ -1,0 +1,188 @@
+// Based on bevy_pbr/render/mesh.wgsl
+#import bevy_pbr::{
+    pbr_fragment::pbr_input_from_standard_material,
+    pbr_functions::alpha_discard,
+}
+
+#ifdef PREPASS_PIPELINE
+#import bevy_pbr::{
+    prepass_io::{Vertex, VertexOutput, FragmentOutput},
+    prepass::vertex,
+    pbr_deferred_functions::deferred_output,
+}
+#else
+#import bevy_pbr::{
+    forward_io::{Vertex, VertexOutput, FragmentOutput},
+    pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
+}
+#endif
+
+struct ChunkVertex {
+    @builtin(instance_index) instance_index: u32,
+    @location(0) position: vec3<f32>,
+    @location(1) normal: vec3<f32>,
+    #ifdef VERTEX_UVS_A
+        @location(2) uv: vec2<f32>,
+    #endif
+    #ifdef VERTEX_UVS_B
+        @location(3) uv_b: vec2<f32>,
+    #endif
+    #ifdef VERTEX_TANGENTS
+        @location(4) tangent: vec4<f32>,
+    #endif
+    @location(5) color: vec4<f32>,
+    @location(6) barycentric_color_offset: vec3<f32>,
+    @location(7) block_index_with_flags: u32,
+}
+
+struct ChunkVertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) world_position: vec4<f32>,
+    @location(1) world_normal: vec3<f32>,
+#ifdef VERTEX_UVS_A
+    @location(2) uv: vec2<f32>,
+#endif
+#ifdef VERTEX_UVS_B
+    @location(3) uv_b: vec2<f32>,
+#endif
+#ifdef VERTEX_TANGENTS
+    @location(4) world_tangent: vec4<f32>,
+#endif
+    @location(5) color: vec4<f32>,
+#ifdef VERTEX_OUTPUT_INSTANCE_INDEX
+    @location(6) @interpolate(flat) instance_index: u32,
+#endif
+    @location(7) barycentric_coords: vec3<f32>,
+    @location(8) barycentric_color_offset: vec3<f32>,
+    @location(9) block_index: u32,
+}
+
+/*
+// If we decide we need material-wide uniforms, here's how to add them
+
+struct ChunkMeshMaterial {
+}
+
+@group(2) @binding(100)
+var<uniform> chunk_mesh_material: ChunkMeshMaterial;
+*/
+
+#import bevy_pbr::{
+    mesh_bindings::mesh,
+    mesh_functions,
+    skinning,
+    morph::morph,
+    view_transformations::position_world_to_clip,
+}
+
+@vertex
+fn vertex(vertex: ChunkVertex) -> ChunkVertexOutput {
+    var out: ChunkVertexOutput;
+
+    let mesh_world_from_local = mesh_functions::get_world_from_local(vertex.instance_index);
+
+    // Use vertex.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416 .
+    var world_from_local = mesh_world_from_local;
+
+#ifdef VERTEX_NORMALS
+    out.world_normal = mesh_functions::mesh_normal_local_to_world(
+        vertex.normal,
+        // Use vertex.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+        // See https://github.com/gfx-rs/naga/issues/2416
+        vertex.instance_index
+    );
+#endif
+
+    out.world_position = mesh_functions::mesh_position_local_to_world(world_from_local, vec4<f32>(vertex.position, 1.0));
+    out.position = position_world_to_clip(out.world_position.xyz);
+
+#ifdef VERTEX_UVS_A
+    out.uv = vertex.uv;
+#endif
+#ifdef VERTEX_UVS_B
+    out.uv_b = vertex.uv_b;
+#endif
+
+#ifdef VERTEX_TANGENTS
+    out.world_tangent = mesh_functions::mesh_tangent_local_to_world(
+        world_from_local,
+        vertex.tangent,
+        // Use vertex.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+        // See https://github.com/gfx-rs/naga/issues/2416
+        vertex.instance_index
+    );
+#endif
+
+    out.color = vertex.color;
+
+#ifdef VERTEX_OUTPUT_INSTANCE_INDEX
+    // Use vertex.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416
+    out.instance_index = vertex.instance_index;
+#endif
+
+#ifdef VISIBILITY_RANGE_DITHER
+    out.visibility_range_dither = mesh_functions::get_visibility_range_dither_level(
+        vertex.instance_index, mesh_world_from_local[3]);
+#endif
+
+    var index = vertex.block_index_with_flags;
+    var baryx = f32((index & (1u << 17u)) > 0u);
+    var baryy = f32((index & (1u << 18u)) > 0u);
+    var baryz = f32((index & (1u << 19u)) > 0u);
+    out.barycentric_coords = vec3<f32>(baryx, baryy, baryz);
+    out.barycentric_color_offset = vertex.barycentric_color_offset;
+    out.block_index = vertex.block_index_with_flags & ((1u << 17u) - 1u);
+
+    return out;
+}
+
+@fragment
+fn fragment(
+    chunk_in: ChunkVertexOutput,
+    @builtin(front_facing) is_front: bool,
+) -> FragmentOutput {
+    var in: VertexOutput;
+    in.position = chunk_in.position;
+    in.world_position = chunk_in.world_position;
+    in.world_normal = chunk_in.world_normal;
+#ifdef VERTEX_UVS_A
+    in.uv = chunk_in.uv;
+#endif
+#ifdef VERTEX_UVS_B
+    in.uv_b = chunk_in.uv_b;
+#endif
+#ifdef VERTEX_TANGENTS
+    in.world_tangent = chunk_in.world_tangent;
+#endif
+    in.color = chunk_in.color;
+#ifdef VERTEX_OUTPUT_INSTANCE_INDEX
+    in.instance_index = chunk_in.instance_index;
+#endif
+
+    // generate a PbrInput struct from the StandardMaterial bindings
+    var pbr_input = pbr_input_from_standard_material(in, is_front);
+
+    // we can optionally modify the input before lighting and alpha_discard is applied
+    var corrected_v_color = pbr_input.material.base_color.xyz + chunk_in.barycentric_coords.x * chunk_in.barycentric_coords.y * chunk_in.barycentric_color_offset;
+    pbr_input.material.base_color = vec4(corrected_v_color, pbr_input.material.base_color.w);
+
+    // alpha discard
+    pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
+
+#ifdef PREPASS_PIPELINE
+    // in deferred mode we can't modify anything after that, as lighting is run in a separate fullscreen shader.
+    let out = deferred_output(in, pbr_input);
+#else
+    var out: FragmentOutput;
+    // apply lighting
+    out.color = apply_pbr_lighting(pbr_input);
+
+    // apply in-shader post processing (fog, alpha-premultiply, and also tonemapping, debanding if the camera is non-hdr)
+    // note this does not include fullscreen postprocessing effects like bloom.
+    out.color = main_pass_post_lighting_processing(pbr_input, out.color);
+#endif
+
+    return out;
+}

--- a/assets/shaders/chunk_mesh_main.wgsl
+++ b/assets/shaders/chunk_mesh_main.wgsl
@@ -48,11 +48,11 @@ struct ChunkVertexOutput {
 #ifdef VERTEX_TANGENTS
     @location(4) world_tangent: vec4<f32>,
 #endif
-    @location(5) color: vec4<f32>,
+    @location(5) @interpolate(linear, center) color: vec4<f32>,
 #ifdef VERTEX_OUTPUT_INSTANCE_INDEX
     @location(6) @interpolate(flat) instance_index: u32,
 #endif
-    @location(7) barycentric_coords: vec3<f32>,
+    @location(7) barycentric_coords: vec2<f32>,
     @location(8) barycentric_color_offset: vec3<f32>,
     @location(9) block_index: u32,
 }
@@ -130,8 +130,7 @@ fn vertex(vertex: ChunkVertex) -> ChunkVertexOutput {
     var index = vertex.block_index_with_flags;
     var baryx = f32((index & (1u << 17u)) > 0u);
     var baryy = f32((index & (1u << 18u)) > 0u);
-    var baryz = f32((index & (1u << 19u)) > 0u);
-    out.barycentric_coords = vec3<f32>(baryx, baryy, baryz);
+    out.barycentric_coords = vec2<f32>(baryx, baryy);
     out.barycentric_color_offset = vertex.barycentric_color_offset;
     out.block_index = vertex.block_index_with_flags & ((1u << 17u) - 1u);
 

--- a/crates/gs_client/Cargo.toml
+++ b/crates/gs_client/Cargo.toml
@@ -47,6 +47,7 @@ features = [
     "bevy_text",          # Text/font rendering
     "bevy_ui",            # UI toolkit
     "bevy_color",         # Color space types
+    "bevy_gizmos",        # Immediate mode debug rendering
     "tonemapping_luts",   # Support different camera Tonemapping modes (embeds extra data)
     "x11",                # Linux: Support X11 windowing system
 

--- a/crates/gs_client/src/debugcam.rs
+++ b/crates/gs_client/src/debugcam.rs
@@ -4,7 +4,9 @@
 //
 //THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+use bevy::color::palettes::tailwind;
 use bevy::input::mouse::AccumulatedMouseMotion;
+use bevy::math::vec3;
 use bevy::prelude::*;
 use bevy::window::{CursorGrabMode, PrimaryWindow};
 
@@ -199,6 +201,18 @@ fn player_look(
     }
 }
 
+fn xyz_gizmo(camera_query: Query<&Transform, With<FlyCam>>, mut gizmos: Gizmos) {
+    let len = 0.5;
+    let Ok(&camera) = camera_query.get_single() else {
+        return;
+    };
+    let arrow_start = camera.transform_point(vec3(0.0, 0.0, -4.0));
+    gizmos.sphere(arrow_start, len, tailwind::GRAY_700);
+    gizmos.arrow(arrow_start, arrow_start + len * Vec3::X, tailwind::RED_600);
+    gizmos.arrow(arrow_start, arrow_start + len * Vec3::Y, tailwind::GREEN_600);
+    gizmos.arrow(arrow_start, arrow_start + len * Vec3::Z, tailwind::BLUE_600);
+}
+
 fn cursor_grab(
     keys: Res<ButtonInput<KeyCode>>,
     key_bindings: Res<KeyBindings>,
@@ -210,22 +224,6 @@ fn cursor_grab(
         }
     } else {
         warn!("Primary window not found for `cursor_grab`!");
-    }
-}
-
-// Grab cursor when an entity with FlyCam is added
-fn initial_grab_on_flycam_spawn(
-    mut primary_window: Query<&mut Window, With<PrimaryWindow>>,
-    query_added: Query<Entity, Added<FlyCam>>,
-) {
-    if query_added.is_empty() {
-        return;
-    }
-
-    if let Ok(window) = &mut primary_window.get_single_mut() {
-        toggle_grab_cursor(window);
-    } else {
-        warn!("Primary window not found for `initial_grab_cursor`!");
     }
 }
 
@@ -281,21 +279,10 @@ impl Plugin for PlayerPlugin {
             .add_systems(OnEnter(ClientAppState::InGame), spawn_debug_text)
             .add_systems(Update, player_move.in_set(InGameSystemSet))
             .add_systems(Update, player_look.in_set(InGameSystemSet))
-            .add_systems(Update, cursor_grab.in_set(InGameSystemSet));
-    }
-}
-
-/// Same as [`PlayerPlugin`] but does not spawn a camera
-pub struct NoCameraPlayerPlugin;
-impl Plugin for NoCameraPlayerPlugin {
-    fn build(&self, app: &mut App) {
-        app.init_resource::<MovementSettings>()
-            .init_resource::<KeyBindings>()
-            .add_systems(OnEnter(ClientAppState::InGame), initial_grab_cursor)
-            .add_systems(OnEnter(ClientAppState::InGame), initial_grab_on_flycam_spawn)
-            .add_systems(OnEnter(ClientAppState::InGame), spawn_debug_text)
-            .add_systems(Update, player_move.in_set(InGameSystemSet))
-            .add_systems(Update, player_look.in_set(InGameSystemSet))
+            .add_systems(
+                Update,
+                xyz_gizmo.in_set(InGameSystemSet).after(player_move).after(player_look),
+            )
             .add_systems(Update, cursor_grab.in_set(InGameSystemSet));
     }
 }

--- a/crates/gs_client/src/lib.rs
+++ b/crates/gs_client/src/lib.rs
@@ -35,7 +35,6 @@ use bevy::winit::WinitPlugin;
 use bevy_egui::EguiPlugin;
 use gs_common::network::thread::NetworkThread;
 use gs_common::prelude::*;
-use gs_common::voxel::plugin::VoxelUniversePlugin;
 use gs_common::{GameBevyCommand, GAME_BRAND_NAME};
 use gs_schemas::dependencies::smallvec::SmallVec;
 use gs_schemas::registries::GameRegistries;
@@ -43,6 +42,7 @@ use gs_schemas::{GameSide, GsExtraData};
 use states::{ClientAppState, InGameSystemSet, LoadingGameSystemSet, MainMenuSystemSet};
 
 use crate::network::NetworkThreadClientState;
+use crate::voxel::client_plugin::VoxelUniverseClientPlugin;
 
 /// An [`GsExtraData`] implementation containing the client-side data for the game engine.
 #[derive(Resource)]
@@ -139,7 +139,7 @@ pub fn client_main() {
     configure_sets(&mut app, FixedPostUpdate);
 
     app.add_plugins(debugcam::PlayerPlugin)
-        .add_plugins(VoxelUniversePlugin::<ClientData>::new())
+        .add_plugins(VoxelUniverseClientPlugin)
         .add_plugins(states::main_menu::MainMenuPlugin)
         .add_plugins(states::loading_game::LoadingGamePlugin)
         .add_plugins(states::in_game::InGamePlugin);

--- a/crates/gs_client/src/lib.rs
+++ b/crates/gs_client/src/lib.rs
@@ -17,6 +17,7 @@ use bevy::audio::AudioPlugin;
 use bevy::core_pipeline::CorePipelinePlugin;
 use bevy::diagnostic::DiagnosticsPlugin;
 use bevy::ecs::schedule::ScheduleLabel;
+use bevy::gizmos::GizmoPlugin;
 use bevy::gltf::GltfPlugin;
 use bevy::input::InputPlugin;
 use bevy::pbr::PbrPlugin;
@@ -115,6 +116,7 @@ pub fn client_main() {
         .add_plugins(PbrPlugin::default())
         .add_plugins(AudioPlugin::default())
         .add_plugins(GilrsPlugin)
+        .add_plugins(GizmoPlugin)
         .add_plugins(AnimationPlugin)
         .add_plugins(GltfPlugin::default());
     // Bevy plugins
@@ -169,6 +171,10 @@ fn control_command_handler_system(world: &mut World) {
 }
 
 mod debug_window {
+    use std::f32::consts::PI;
+
+    use bevy::color::palettes::tailwind;
+    use bevy::math::vec3;
     use bevy::prelude::*;
 
     pub struct DebugWindow;
@@ -186,11 +192,31 @@ mod debug_window {
         commands.spawn((
             DirectionalLight {
                 shadows_enabled: false,
-                illuminance: 1000.0,
+                illuminance: light_consts::lux::AMBIENT_DAYLIGHT * 0.75,
                 ..default()
             },
-            Transform::from_xyz(0., 1000., 0.).looking_at(Vec3::new(300.0, 0.0, 300.0), Vec3::Y),
+            Transform {
+                translation: vec3(0.0, 1000.0, 0.0),
+                rotation: Quat::from_rotation_x(PI / 4.0) * Quat::from_rotation_y(PI / 16.0),
+                scale: Vec3::ONE,
+            },
         ));
+        commands.spawn((
+            DirectionalLight {
+                shadows_enabled: false,
+                illuminance: light_consts::lux::AMBIENT_DAYLIGHT * 0.25,
+                ..default()
+            },
+            Transform {
+                translation: vec3(0.0, 1000.0, 0.0),
+                rotation: Quat::from_rotation_x(PI / 4.0) * Quat::from_rotation_y(PI + PI / 16.0),
+                scale: Vec3::ONE,
+            },
+        ));
+        commands.insert_resource(AmbientLight {
+            color: tailwind::GRAY_50.into(),
+            brightness: 10.0,
+        });
         warn!("Setting up debug window done");
     }
 }

--- a/crates/gs_client/src/voxel/client_plugin.rs
+++ b/crates/gs_client/src/voxel/client_plugin.rs
@@ -1,0 +1,17 @@
+//! Bevy [`Plugin`] for the client voxel universe functionality.
+use bevy::prelude::*;
+use gs_common::voxel::plugin::VoxelUniversePlugin;
+
+use crate::voxel::meshgen::ChunkMeshMaterial;
+use crate::ClientData;
+
+/// Initializes the required plugins for client-side voxel universe support.
+#[derive(Default)]
+pub struct VoxelUniverseClientPlugin;
+
+impl Plugin for VoxelUniverseClientPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(VoxelUniversePlugin::<ClientData>::new())
+            .add_plugins(MaterialPlugin::<ChunkMeshMaterial>::default());
+    }
+}

--- a/crates/gs_client/src/voxel/meshgen.rs
+++ b/crates/gs_client/src/voxel/meshgen.rs
@@ -58,7 +58,8 @@ pub type ChunkMeshMaterial = ExtendedMaterial<StandardMaterial, ChunkMeshMateria
 pub fn default_chunk_material() -> ChunkMeshMaterial {
     ChunkMeshMaterial {
         base: StandardMaterial {
-            base_color: tailwind::GRAY_500.into(),
+            base_color: tailwind::GRAY_100.into(),
+            perceptual_roughness: 1.0,
             ..default()
         },
         extension: ChunkMeshMaterialExtension {},
@@ -175,7 +176,7 @@ pub fn mesh_from_chunk(registry: &BlockRegistry, chunks: &ChunkRefNeighborhood<C
                 // Ambient Occlusion
                 let mut ao = 1.0;
                 for &ao_off in vtx.ao_offsets.iter() {
-                    let pos = ipos + RelBlockPos::from(vor.apply_to_ivec(ao_off));
+                    let pos = ipos + RelBlockPos::from(vor.unapply_to_ivec(ao_off));
                     let bentry = get_block(chunks, pos);
                     let bdef = registry.lookup_id_to_object(bentry.id).context("invalid block")?;
                     let bstdmeta = StandardShapeMetadata::from_meta(bentry.metadata);
@@ -199,12 +200,12 @@ pub fn mesh_from_chunk(registry: &BlockRegistry, chunks: &ChunkRefNeighborhood<C
                 let normal: [f32; 3] = vnormal.to_array();
                 // let texid = *vdef.texture_mapping.at_direction(rot_side_dir);
                 let color = [
-                    vdef.representative_color.r as f32 * ao,
-                    vdef.representative_color.g as f32 * ao,
-                    vdef.representative_color.b as f32 * ao,
+                    vdef.representative_color.red * ao,
+                    vdef.representative_color.green * ao,
+                    vdef.representative_color.blue * ao,
                     1.0,
                 ];
-                barycentric_color_sum += vtx.barycentric_sign as f32 * Vec4::from(color);
+                barycentric_color_sum += vtx.barycentric_sign * Vec4::from(color);
 
                 let mut idx_flags = ipos_as_offset;
                 if vtx.barycentric.x > 0.1 {
@@ -212,9 +213,6 @@ pub fn mesh_from_chunk(registry: &BlockRegistry, chunks: &ChunkRefNeighborhood<C
                 }
                 if vtx.barycentric.y > 0.1 {
                     idx_flags |= 1 << 18;
-                }
-                if vtx.barycentric.z > 0.1 {
-                    idx_flags |= 1 << 19;
                 }
 
                 pos_buf.push(position);

--- a/crates/gs_common/src/voxel/biomes.rs
+++ b/crates/gs_common/src/voxel/biomes.rs
@@ -1,9 +1,9 @@
 //! The builtin biome types.
 //! Most of this will be moved to a "base" mod at some point in the future.
 
+use bevy::color::Srgba;
 use gs_schemas::voxel::generation::fbm_noise::Fbm;
 use gs_schemas::{
-    dependencies::rgb::RGBA8,
     range::range,
     registry::RegistryName,
     voxel::{
@@ -36,7 +36,7 @@ pub fn setup_basic_biomes(biome_registry: &mut BiomeRegistry) {
     biome_registry
         .push_object(BiomeDefinition {
             name: VOID_BIOME_NAME,
-            representative_color: RGBA8::new(0, 0, 0, 0),
+            representative_color: Srgba::rgba_u8(0, 0, 0, 0),
             elevation: range(-1.0..-1.0),
             temperature: range(-1.0..-1.0),
             moisture: range(-1.0..-1.0),
@@ -51,7 +51,7 @@ pub fn setup_basic_biomes(biome_registry: &mut BiomeRegistry) {
     biome_registry
         .push_object(BiomeDefinition {
             name: PLAINS_BIOME_NAME,
-            representative_color: RGBA8::new(20, 180, 10, 255),
+            representative_color: Srgba::rgba_u8(20, 180, 10, 255),
             elevation: range(0.5..1.5),
             temperature: range(..),
             moisture: range(..),
@@ -94,7 +94,7 @@ pub fn setup_basic_biomes(biome_registry: &mut BiomeRegistry) {
     biome_registry
         .push_object(BiomeDefinition {
             name: HILLS_BIOME_NAME,
-            representative_color: RGBA8::new(15, 110, 10, 255),
+            representative_color: Srgba::rgba_u8(15, 110, 10, 255),
             elevation: range(1.5..3.0),
             temperature: range(..),
             moisture: range(..),
@@ -139,7 +139,7 @@ pub fn setup_basic_biomes(biome_registry: &mut BiomeRegistry) {
     biome_registry
         .push_object(BiomeDefinition {
             name: MOUNTAINS_BIOME_NAME,
-            representative_color: RGBA8::new(220, 220, 220, 255),
+            representative_color: Srgba::rgba_u8(220, 220, 220, 255),
             elevation: range(3.0..),
             temperature: range(..),
             moisture: range(..),
@@ -188,7 +188,7 @@ pub fn setup_basic_biomes(biome_registry: &mut BiomeRegistry) {
     biome_registry
         .push_object(BiomeDefinition {
             name: OCEAN_BIOME_NAME,
-            representative_color: RGBA8::new(10, 120, 180, 255),
+            representative_color: Srgba::rgba_u8(10, 120, 180, 255),
             elevation: range(..1.0),
             temperature: range(..),
             moisture: range(2.5..),
@@ -217,7 +217,7 @@ pub fn setup_basic_biomes(biome_registry: &mut BiomeRegistry) {
     biome_registry
         .push_object(BiomeDefinition {
             name: BEACH_BIOME_NAME,
-            representative_color: RGBA8::new(224, 200, 130, 255),
+            representative_color: Srgba::rgba_u8(224, 200, 130, 255),
             elevation: range(1.0..),
             temperature: range(..),
             moisture: range(2.5..),
@@ -244,7 +244,7 @@ pub fn setup_basic_biomes(biome_registry: &mut BiomeRegistry) {
     biome_registry
         .push_object(BiomeDefinition {
             name: RIVER_BIOME_NAME,
-            representative_color: RGBA8::new(10, 100, 200, 255),
+            representative_color: Srgba::rgba_u8(10, 100, 200, 255),
             elevation: range(..),
             temperature: range(..),
             moisture: range(..),

--- a/crates/gs_common/src/voxel/blocks.rs
+++ b/crates/gs_common/src/voxel/blocks.rs
@@ -1,7 +1,7 @@
 //! The builtin block types.
 //! Most of this will be moved to a "base" mod at some point in the future.
 
-use gs_schemas::dependencies::rgb::RGBA8;
+use bevy::color::Srgba;
 use gs_schemas::registry::RegistryName;
 use gs_schemas::voxel::voxeltypes::BlockShapeSet::StandardShapedMaterial;
 use gs_schemas::voxel::voxeltypes::{BlockDefinition, BlockRegistry, EMPTY_BLOCK};
@@ -26,7 +26,7 @@ pub fn setup_basic_blocks(registry: &mut BlockRegistry) {
         .push_object(BlockDefinition {
             name: STONE_BLOCK_NAME,
             shape_set: StandardShapedMaterial,
-            representative_color: RGBA8::new(64, 64, 64, 255),
+            representative_color: Srgba::rgba_u8(64, 64, 64, 255),
             has_collision_box: true,
             has_drawable_mesh: true,
         })
@@ -35,7 +35,7 @@ pub fn setup_basic_blocks(registry: &mut BlockRegistry) {
         .push_object(BlockDefinition {
             name: DIRT_BLOCK_NAME,
             shape_set: StandardShapedMaterial,
-            representative_color: RGBA8::new(110, 81, 0, 255),
+            representative_color: Srgba::rgba_u8(110, 81, 0, 255),
             has_collision_box: true,
             has_drawable_mesh: true,
         })
@@ -44,7 +44,7 @@ pub fn setup_basic_blocks(registry: &mut BlockRegistry) {
         .push_object(BlockDefinition {
             name: GRASS_BLOCK_NAME,
             shape_set: StandardShapedMaterial,
-            representative_color: RGBA8::new(30, 230, 30, 255),
+            representative_color: Srgba::rgba_u8(30, 230, 30, 255),
             has_collision_box: true,
             has_drawable_mesh: true,
         })
@@ -53,7 +53,7 @@ pub fn setup_basic_blocks(registry: &mut BlockRegistry) {
         .push_object(BlockDefinition {
             name: SNOWY_GRASS_BLOCK_NAME,
             shape_set: StandardShapedMaterial,
-            representative_color: RGBA8::new(200, 200, 200, 255),
+            representative_color: Srgba::rgba_u8(200, 200, 200, 255),
             has_collision_box: true,
             has_drawable_mesh: true,
         })
@@ -62,7 +62,7 @@ pub fn setup_basic_blocks(registry: &mut BlockRegistry) {
         .push_object(BlockDefinition {
             name: WATER_BLOCK_NAME,
             shape_set: StandardShapedMaterial,
-            representative_color: RGBA8::new(0, 0, 200, 100),
+            representative_color: Srgba::rgba_u8(0, 0, 200, 100),
             has_collision_box: false,
             has_drawable_mesh: true,
         })
@@ -71,7 +71,7 @@ pub fn setup_basic_blocks(registry: &mut BlockRegistry) {
         .push_object(BlockDefinition {
             name: SAND_BLOCK_NAME,
             shape_set: StandardShapedMaterial,
-            representative_color: RGBA8::new(224, 200, 130, 255),
+            representative_color: Srgba::rgba_u8(224, 200, 130, 255),
             has_collision_box: true,
             has_drawable_mesh: true,
         })

--- a/lib/gs_schemas/Cargo.toml
+++ b/lib/gs_schemas/Cargo.toml
@@ -23,6 +23,7 @@ bytemuck.workspace = true
 bitflags.workspace = true
 bitvec.workspace = true
 bevy_math.workspace = true
+bevy_color.workspace = true
 bevy_reflect.workspace = true
 capnp.workspace = true
 either.workspace = true

--- a/lib/gs_schemas/capnp-generated/game_types_capnp.rs
+++ b/lib/gs_schemas/capnp-generated/game_types_capnp.rs
@@ -203,13 +203,14 @@ pub mod option { /* T */
   impl<T> Pipeline<T> where T: ::capnp::traits::Pipelined, <T as ::capnp::traits::Pipelined>::Pipeline: ::capnp::capability::FromTypelessPipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 50] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 51] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(54, 251, 119, 44, 109, 200, 161, 139),
       ::capnp::word(17, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(1, 0, 7, 0, 0, 0, 2, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(138, 0, 0, 0, 240, 0, 0, 0),
       ::capnp::word(21, 0, 0, 0, 194, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -505,13 +506,14 @@ pub mod result { /* Ok,Err */
   impl<Ok,Err> Pipeline<Ok,Err> where Ok: ::capnp::traits::Pipelined, <Ok as ::capnp::traits::Pipelined>::Pipeline: ::capnp::capability::FromTypelessPipeline, Err: ::capnp::traits::Pipelined, <Err as ::capnp::traits::Pipelined>::Pipeline: ::capnp::capability::FromTypelessPipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 52] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 53] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(33, 128, 123, 71, 89, 82, 63, 143),
       ::capnp::word(17, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(1, 0, 7, 0, 0, 0, 2, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(242, 0, 0, 0, 91, 1, 0, 0),
       ::capnp::word(21, 0, 0, 0, 194, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -798,13 +800,14 @@ pub mod version {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 94] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 95] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(196, 145, 230, 182, 3, 247, 143, 131),
       ::capnp::word(17, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(93, 1, 0, 0, 20, 2, 0, 0),
       ::capnp::word(21, 0, 0, 0, 202, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1070,13 +1073,14 @@ pub mod uuid {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 47] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 48] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(145, 234, 125, 172, 115, 96, 57, 173),
       ::capnp::word(17, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(22, 2, 0, 0, 98, 2, 0, 0),
       ::capnp::word(21, 0, 0, 0, 178, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1292,13 +1296,14 @@ pub mod i_vec2 {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 47] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 48] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(82, 140, 244, 145, 229, 59, 41, 130),
       ::capnp::word(17, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(120, 2, 0, 0, 190, 2, 0, 0),
       ::capnp::word(21, 0, 0, 0, 186, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1526,13 +1531,14 @@ pub mod i_vec3 {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 62] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 63] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(142, 136, 96, 220, 125, 236, 86, 134),
       ::capnp::word(17, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(192, 2, 0, 0, 23, 3, 0, 0),
       ::capnp::word(21, 0, 0, 0, 186, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1776,13 +1782,14 @@ pub mod i64_vec2 {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 63] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 64] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(212, 22, 196, 242, 173, 197, 161, 245),
       ::capnp::word(17, 0, 0, 0, 1, 0, 3, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(25, 3, 0, 0, 114, 3, 0, 0),
       ::capnp::word(21, 0, 0, 0, 202, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2027,13 +2034,14 @@ pub mod i64_vec3 {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 63] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 64] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(102, 87, 117, 171, 239, 53, 128, 146),
       ::capnp::word(17, 0, 0, 0, 1, 0, 3, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(116, 3, 0, 0, 205, 3, 0, 0),
       ::capnp::word(21, 0, 0, 0, 202, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2266,13 +2274,14 @@ pub mod vec2 {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 47] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 48] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(185, 44, 39, 238, 13, 44, 164, 166),
       ::capnp::word(17, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(207, 3, 0, 0, 24, 4, 0, 0),
       ::capnp::word(21, 0, 0, 0, 178, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2500,13 +2509,14 @@ pub mod vec3 {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 62] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 63] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(192, 225, 96, 132, 199, 180, 105, 237),
       ::capnp::word(17, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(26, 4, 0, 0, 118, 4, 0, 0),
       ::capnp::word(21, 0, 0, 0, 178, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2762,13 +2772,14 @@ pub mod quat {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 77] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 78] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(125, 106, 147, 224, 107, 140, 185, 250),
       ::capnp::word(17, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(120, 4, 0, 0, 231, 4, 0, 0),
       ::capnp::word(21, 0, 0, 0, 178, 0, 0, 0),
       ::capnp::word(29, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3040,13 +3051,14 @@ pub mod registry_name {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 48] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 49] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(106, 113, 175, 230, 187, 23, 222, 187),
       ::capnp::word(17, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(8, 5, 0, 0, 86, 5, 0, 0),
       ::capnp::word(21, 0, 0, 0, 242, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3311,13 +3323,14 @@ pub mod registry_id_mapping_bundle {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 77] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 78] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(61, 148, 9, 98, 8, 108, 201, 225),
       ::capnp::word(17, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(3, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(88, 5, 0, 0, 52, 6, 0, 0),
       ::capnp::word(21, 0, 0, 0, 74, 1, 0, 0),
       ::capnp::word(41, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3621,13 +3634,14 @@ pub mod game_bootstrap_data {
     }
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 67] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 68] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(229, 87, 60, 137, 65, 137, 119, 176),
       ::capnp::word(17, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(3, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(134, 6, 0, 0, 233, 7, 0, 0),
       ::capnp::word(21, 0, 0, 0, 26, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3888,13 +3902,14 @@ pub mod full_chunk_data {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 58] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 59] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(76, 101, 84, 137, 193, 207, 247, 142),
       ::capnp::word(17, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(235, 7, 0, 0, 70, 8, 0, 0),
       ::capnp::word(21, 0, 0, 0, 250, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),

--- a/lib/gs_schemas/capnp-generated/network_capnp.rs
+++ b/lib/gs_schemas/capnp-generated/network_capnp.rs
@@ -339,13 +339,14 @@ pub mod game_server {
       }
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 98] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 99] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(110, 17, 87, 193, 68, 35, 66, 233),
         ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
         ::capnp::word(29, 32, 214, 224, 67, 7, 50, 240),
         ::capnp::word(3, 0, 7, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(28, 1, 0, 0, 115, 2, 0, 0),
         ::capnp::word(21, 0, 0, 0, 18, 1, 0, 0),
         ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -591,12 +592,13 @@ pub mod game_server {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 19] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 20] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(4, 251, 176, 175, 126, 255, 195, 234),
         ::capnp::word(25, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 146, 1, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -784,12 +786,13 @@ pub mod game_server {
       }
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 36] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 37] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(146, 139, 246, 220, 168, 238, 105, 239),
         ::capnp::word(25, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 154, 1, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -982,12 +985,13 @@ pub mod game_server {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 33] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 34] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(65, 55, 46, 36, 147, 183, 122, 156),
         ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 42, 1, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1177,12 +1181,13 @@ pub mod game_server {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 33] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 34] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(138, 104, 136, 28, 249, 226, 29, 163),
         ::capnp::word(25, 0, 0, 0, 1, 0, 1, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 50, 1, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1407,12 +1412,13 @@ pub mod game_server {
       }
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 51] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 52] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(91, 101, 173, 141, 103, 59, 223, 134),
         ::capnp::word(25, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 106, 1, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1636,12 +1642,13 @@ pub mod game_server {
       }
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 52] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 53] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(52, 55, 159, 241, 201, 245, 197, 174),
         ::capnp::word(25, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 114, 1, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1875,13 +1882,14 @@ pub mod authentication_error {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 52] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 53] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(30, 92, 52, 93, 118, 217, 212, 158),
       ::capnp::word(14, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(203, 38, 210, 159, 176, 70, 145, 184),
       ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(9, 4, 0, 0, 241, 4, 0, 0),
       ::capnp::word(21, 0, 0, 0, 18, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 23, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -1986,13 +1994,14 @@ pub mod authentication_error {
     const TYPE_ID: u64 = 0x8a27_ac92_9250_061au64;
   }
   mod kind {
-  pub static ENCODED_NODE: [::capnp::Word; 39] = [
-    ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+  pub static ENCODED_NODE: [::capnp::Word; 40] = [
+    ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
     ::capnp::word(26, 6, 80, 146, 146, 172, 39, 138),
     ::capnp::word(34, 0, 0, 0, 2, 0, 0, 0),
     ::capnp::word(30, 92, 52, 93, 118, 217, 212, 158),
     ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+    ::capnp::word(62, 4, 0, 0, 198, 4, 0, 0),
     ::capnp::word(21, 0, 0, 0, 58, 1, 0, 0),
     ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
     ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2218,13 +2227,14 @@ pub mod stream_header {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 54] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 55] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(114, 127, 139, 136, 42, 90, 175, 249),
       ::capnp::word(14, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(203, 38, 210, 159, 176, 70, 145, 184),
       ::capnp::word(1, 0, 7, 0, 0, 0, 2, 0),
       ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(87, 6, 0, 0, 98, 7, 0, 0),
       ::capnp::word(21, 0, 0, 0, 218, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 23, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2331,13 +2341,14 @@ pub mod stream_header {
     const TYPE_ID: u64 = 0xf8e4_acec_8796_8448u64;
   }
   mod standard_types {
-  pub static ENCODED_NODE: [::capnp::Word; 25] = [
-    ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+  pub static ENCODED_NODE: [::capnp::Word; 26] = [
+    ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
     ::capnp::word(72, 132, 150, 135, 236, 172, 228, 248),
     ::capnp::word(27, 0, 0, 0, 2, 0, 0, 0),
     ::capnp::word(114, 127, 139, 136, 42, 90, 175, 249),
     ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
     ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+    ::capnp::word(113, 6, 0, 0, 248, 6, 0, 0),
     ::capnp::word(21, 0, 0, 0, 74, 1, 0, 0),
     ::capnp::word(41, 0, 0, 0, 7, 0, 0, 0),
     ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2630,13 +2641,14 @@ pub mod authenticated_client_connection {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 56] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 57] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(134, 178, 156, 221, 154, 54, 74, 198),
         ::capnp::word(44, 0, 0, 0, 1, 0, 1, 0),
         ::capnp::word(25, 32, 212, 51, 202, 200, 212, 221),
         ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(180, 8, 0, 0, 149, 9, 0, 0),
         ::capnp::word(21, 0, 0, 0, 18, 2, 0, 0),
         ::capnp::word(53, 0, 0, 0, 23, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2743,13 +2755,14 @@ pub mod authenticated_client_connection {
       const TYPE_ID: u64 = 0xf725_13a0_7b41_b403u64;
     }
     mod kind {
-    pub static ENCODED_NODE: [::capnp::Word; 36] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 37] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(3, 180, 65, 123, 160, 19, 37, 247),
       ::capnp::word(66, 0, 0, 0, 2, 0, 0, 0),
       ::capnp::word(134, 178, 156, 221, 154, 54, 74, 198),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(239, 8, 0, 0, 94, 9, 0, 0),
       ::capnp::word(21, 0, 0, 0, 58, 2, 0, 0),
       ::capnp::word(53, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -2940,12 +2953,13 @@ pub mod authenticated_client_connection {
       }
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 37] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 38] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(30, 117, 39, 240, 87, 98, 95, 253),
         ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 58, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3127,12 +3141,13 @@ pub mod authenticated_client_connection {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 21] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 22] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(222, 27, 236, 223, 44, 67, 26, 229),
         ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 66, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3331,12 +3346,13 @@ pub mod authenticated_client_connection {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 52] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 53] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(105, 228, 112, 8, 255, 152, 241, 142),
         ::capnp::word(44, 0, 0, 0, 1, 0, 1, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 18, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3534,12 +3550,13 @@ pub mod authenticated_client_connection {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 21] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 22] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(165, 73, 212, 168, 176, 5, 83, 165),
         ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 26, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -3807,12 +3824,13 @@ pub mod authenticated_server_connection {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 21] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 22] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(4, 248, 111, 255, 242, 179, 155, 188),
         ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 42, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -4002,12 +4020,13 @@ pub mod authenticated_server_connection {
       }
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 37] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 38] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(117, 156, 85, 224, 191, 242, 7, 154),
         ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 50, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -4213,12 +4232,13 @@ pub mod authenticated_server_connection {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 37] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 38] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(69, 48, 85, 184, 211, 130, 16, 242),
         ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 26, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -4400,12 +4420,13 @@ pub mod authenticated_server_connection {
     impl Pipeline  {
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 21] = [
-        ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+      pub static ENCODED_NODE: [::capnp::Word; 22] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(247, 226, 203, 2, 93, 185, 6, 130),
         ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(21, 0, 0, 0, 34, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -4647,13 +4668,14 @@ pub mod chunk_data_stream_packet {
     }
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 81] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 82] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(77, 52, 86, 185, 123, 167, 233, 255),
       ::capnp::word(14, 0, 0, 0, 1, 0, 2, 0),
       ::capnp::word(203, 38, 210, 159, 176, 70, 145, 184),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(207, 10, 0, 0, 27, 12, 0, 0),
       ::capnp::word(21, 0, 0, 0, 34, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),

--- a/lib/gs_schemas/capnp-generated/voxel_mesh_capnp.rs
+++ b/lib/gs_schemas/capnp-generated/voxel_mesh_capnp.rs
@@ -204,13 +204,14 @@ pub mod voxel_mesh {
     }
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 79] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 80] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(69, 194, 137, 46, 134, 104, 43, 203),
       ::capnp::word(17, 0, 0, 0, 1, 0, 0, 0),
       ::capnp::word(78, 174, 70, 247, 102, 184, 30, 213),
       ::capnp::word(3, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(12, 1, 0, 0, 135, 3, 0, 0),
       ::capnp::word(21, 0, 0, 0, 218, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -514,13 +515,14 @@ pub mod voxel_mesh_side {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 88] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 89] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(92, 56, 61, 108, 217, 93, 204, 159),
       ::capnp::word(17, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(78, 174, 70, 247, 102, 184, 30, 213),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(137, 3, 0, 0, 132, 5, 0, 0),
       ::capnp::word(21, 0, 0, 0, 250, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -935,13 +937,14 @@ pub mod voxel_mesh_vertex {
   impl Pipeline  {
   }
   mod _private {
-    pub static ENCODED_NODE: [::capnp::Word; 243] = [
-      ::capnp::word(0, 0, 0, 0, 5, 0, 6, 0),
+    pub static ENCODED_NODE: [::capnp::Word; 244] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
       ::capnp::word(54, 189, 62, 218, 122, 204, 40, 159),
       ::capnp::word(17, 0, 0, 0, 1, 0, 7, 0),
       ::capnp::word(78, 174, 70, 247, 102, 184, 30, 213),
       ::capnp::word(1, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(134, 5, 0, 0, 101, 9, 0, 0),
       ::capnp::word(21, 0, 0, 0, 10, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),

--- a/lib/gs_schemas/src/direction.rs
+++ b/lib/gs_schemas/src/direction.rs
@@ -17,9 +17,9 @@ pub enum Direction {
     YMinus,
     /// Up/Top
     YPlus,
-    /// Front (into the screen)
+    /// Back (into the screen)
     ZMinus,
-    /// Back (out of the screen)
+    /// Front (out of the screen)
     ZPlus,
 }
 

--- a/lib/gs_schemas/src/lib.rs
+++ b/lib/gs_schemas/src/lib.rs
@@ -45,6 +45,7 @@ pub enum GameSide {
 /// Re-exported dependencies used in API types
 pub mod dependencies {
     pub use anyhow;
+    pub use bevy_color;
     pub use bevy_math;
     pub use bitflags;
     pub use bitvec;
@@ -58,7 +59,6 @@ pub mod dependencies {
     pub use once_cell;
     pub use rand;
     pub use rand_xoshiro;
-    pub use rgb;
     pub use serde;
     pub use smallvec;
     pub use thiserror;

--- a/lib/gs_schemas/src/voxel/biome/mod.rs
+++ b/lib/gs_schemas/src/voxel/biome/mod.rs
@@ -3,9 +3,9 @@
 use std::fmt::{Debug, Display};
 use std::hash::{Hash, Hasher};
 
+use bevy_color::Srgba;
 use bevy_math::DVec2;
 use noise::OpenSimplex;
-use rgb::RGBA8;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -52,7 +52,7 @@ pub struct BiomeDefinition {
     /// The unique registry name
     pub name: RegistryName,
     /// A color that can represent the biome on maps, debug views, etc.
-    pub representative_color: RGBA8,
+    pub representative_color: Srgba,
     /// Can this biome generate in the world?
     pub can_generate: bool,
     /// Elevation of this biome.

--- a/lib/gs_schemas/src/voxel/standard_shapes.rs
+++ b/lib/gs_schemas/src/voxel/standard_shapes.rs
@@ -100,9 +100,9 @@ pub struct VSVertex {
     /// Barycentric coordinate within the voxel face.
     /// <https://www.asawicki.info/news_1721_how_to_correctly_interpolate_vertex_attributes_on_a_parallelogram_using_modern_gpus>
     /// Archive: <https://web.archive.org/web/20200516133048/https://www.asawicki.info/news_1721_how_to_correctly_interpolate_vertex_attributes_on_a_parallelogram_using_modern_gpus>
-    pub barycentric: Vec3A,
+    pub barycentric: Vec2,
     /// Sign when added to the "extra data" sum for proper quadrilateral interpolation
-    pub barycentric_sign: i32,
+    pub barycentric_sign: f32,
     /// List of blocks to check to calculate the ambient occlusion values.
     pub ao_offsets: SmallVec<[IVec3; 4]>,
 }
@@ -151,19 +151,12 @@ fn init_no_shape() -> VoxelShapeDef {
     }
 }
 
-/// A signum function that returns 0 for values x where |x|<0.1
-fn approx_signum(mut v: Vec3A) -> IVec3 {
-    let abs = v.abs();
-    if abs.x < 0.1 {
-        v.x = 0.0;
-    }
-    if abs.y < 0.1 {
-        v.y = 0.0;
-    }
-    if abs.z < 0.1 {
-        v.z = 0.0;
-    }
-    v.signum().as_ivec3()
+/// A signum function that returns 0 for values x where |x|<=0.1
+fn approx_signum(v: Vec3A) -> IVec3 {
+    let v: Vec3 = v.into();
+    let minuses = v.cmple(Vec3::splat(-0.1));
+    let pluses = v.cmpge(Vec3::splat(0.1));
+    IVec3::select(minuses, IVec3::NEG_ONE, IVec3::select(pluses, IVec3::ONE, IVec3::ZERO))
 }
 
 /// Calculates the set of ambient occlusion neighbors from the position&normal at a given vertex.
@@ -192,46 +185,45 @@ fn corner_ao_set(corner: Vec3A, inormal: IVec3) -> SmallVec<[IVec3; 4]> {
 
 /// Constructs a list of vertices for a quad with the given center and local right&up vectors.
 fn quad_verts(center: Vec3A, right: Vec3A, up: Vec3A) -> SmallVec<[VSVertex; 8]> {
-    let fnormal = -right.cross(up);
+    let fnormal = right.cross(up).normalize();
     let inormal = approx_signum(fnormal);
-    let fnormal = fnormal.normalize();
     smallvec![
         VSVertex {
             offset: center - right - up,
             texcoord: Vec2::new(0.0, 1.0),
             normal: fnormal,
-            barycentric: Vec3A::new(0.0, 1.0, 1.0),
-            barycentric_sign: -1,
+            barycentric: Vec2::new(1.0, 0.0),
+            barycentric_sign: -1.0,
             ao_offsets: corner_ao_set(center - right - up, inormal),
         },
         VSVertex {
             offset: center - right + up,
             texcoord: Vec2::new(0.0, 0.0),
             normal: fnormal,
-            barycentric: Vec3A::new(0.0, 0.0, 1.0),
-            barycentric_sign: 1,
+            barycentric: Vec2::new(0.0, 0.0),
+            barycentric_sign: 1.0,
             ao_offsets: corner_ao_set(center - right + up, inormal),
         },
         VSVertex {
             offset: center + right + up,
             texcoord: Vec2::new(1.0, 0.0),
             normal: fnormal,
-            barycentric: Vec3A::new(1.0, 0.0, 1.0),
-            barycentric_sign: -1,
+            barycentric: Vec2::new(0.0, 1.0),
+            barycentric_sign: -1.0,
             ao_offsets: corner_ao_set(center + right + up, inormal),
         },
         VSVertex {
             offset: center + right - up,
             texcoord: Vec2::new(1.0, 1.0),
             normal: fnormal,
-            barycentric: Vec3A::new(0.0, 0.0, 1.0),
-            barycentric_sign: 1,
+            barycentric: Vec2::new(0.0, 0.0),
+            barycentric_sign: 1.0,
             ao_offsets: corner_ao_set(center + right - up, inormal),
         },
     ]
 }
 
-const QUAD_INDICES: [u32; 6] = [0, 1, 2, 2, 3, 0];
+const QUAD_INDICES: [u32; 6] = [0, 2, 1, 3, 2, 0];
 
 fn init_cube_shape() -> VoxelShapeDef {
     VoxelShapeDef {
@@ -243,7 +235,7 @@ fn init_cube_shape() -> VoxelShapeDef {
                 can_be_clipped: true,
                 vertices: quad_verts(
                     Vec3A::new(-0.5, 0.0, 0.0),
-                    Vec3A::new(0.0, 0.0, -0.5),
+                    Vec3A::new(0.0, 0.0, 0.5),
                     Vec3A::new(0.0, 0.5, 0.0),
                 ),
                 indices: SmallVec::from_slice(&QUAD_INDICES),
@@ -254,7 +246,7 @@ fn init_cube_shape() -> VoxelShapeDef {
                 can_be_clipped: true,
                 vertices: quad_verts(
                     Vec3A::new(0.5, 0.0, 0.0),
-                    Vec3A::new(0.0, 0.0, 0.5),
+                    Vec3A::new(0.0, 0.0, -0.5),
                     Vec3A::new(0.0, 0.5, 0.0),
                 ),
                 indices: SmallVec::from_slice(&QUAD_INDICES),
@@ -266,7 +258,7 @@ fn init_cube_shape() -> VoxelShapeDef {
                 vertices: quad_verts(
                     Vec3A::new(0.0, -0.5, 0.0),
                     Vec3A::new(0.5, 0.0, 0.0),
-                    Vec3A::new(0.0, 0.0, -0.5),
+                    Vec3A::new(0.0, 0.0, 0.5),
                 ),
                 indices: SmallVec::from_slice(&QUAD_INDICES),
             },
@@ -277,28 +269,28 @@ fn init_cube_shape() -> VoxelShapeDef {
                 vertices: quad_verts(
                     Vec3A::new(0.0, 0.5, 0.0),
                     Vec3A::new(0.5, 0.0, 0.0),
-                    Vec3A::new(0.0, 0.0, 0.5),
+                    Vec3A::new(0.0, 0.0, -0.5),
                 ),
                 indices: SmallVec::from_slice(&QUAD_INDICES),
             },
-            // Front Z-
+            // Back Z-
             VSSide {
                 can_clip: true,
                 can_be_clipped: true,
                 vertices: quad_verts(
                     Vec3A::new(0.0, 0.0, -0.5),
-                    Vec3A::new(0.5, 0.0, 0.0),
+                    Vec3A::new(-0.5, 0.0, 0.0),
                     Vec3A::new(0.0, 0.5, 0.0),
                 ),
                 indices: SmallVec::from_slice(&QUAD_INDICES),
             },
-            // Back Z+
+            // Front Z+
             VSSide {
                 can_clip: true,
                 can_be_clipped: true,
                 vertices: quad_verts(
                     Vec3A::new(0.0, 0.0, 0.5),
-                    Vec3A::new(-0.5, 0.0, 0.0),
+                    Vec3A::new(0.5, 0.0, 0.0),
                     Vec3A::new(0.0, 0.5, 0.0),
                 ),
                 indices: SmallVec::from_slice(&QUAD_INDICES),
@@ -320,24 +312,24 @@ fn init_slope_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(-0.5, -0.5, 0.5),
                         texcoord: Vec2::new(0.0, 1.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, 1.0), IVec3::new(-1, 0, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, 0.5, 0.5),
                         texcoord: Vec2::new(0.0, 0.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, 1.0, 1.0), IVec3::new(-1, 0, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, -0.5, -0.5),
                         texcoord: Vec2::new(1.0, 1.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, -1.0), IVec3::new(-1, 0, 0)),
                     },
                 ],
@@ -352,24 +344,24 @@ fn init_slope_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(0.5, -0.5, -0.5),
                         texcoord: Vec2::new(0.0, 1.0),
                         normal: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, -1.0, -1.0), IVec3::new(1, 0, 0))
                     },
                     VSVertex {
                         offset: Vec3A::new(0.5, 0.5, 0.5),
                         texcoord: Vec2::new(1.0, 0.0),
                         normal: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, 1.0, 1.0), IVec3::new(1, 0, 0))
                     },
                     VSVertex {
                         offset: Vec3A::new(0.5, -0.5, 0.5),
                         texcoord: Vec2::new(1.0, 1.0),
                         normal: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, -1.0, 1.0), IVec3::new(1, 0, 0))
                     },
                 ],
@@ -432,24 +424,24 @@ fn init_corner_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(-0.5, -0.5, 0.5),
                         texcoord: Vec2::new(0.0, 1.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, 1.0), IVec3::new(-1, 0, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, 0.5, 0.5),
                         texcoord: Vec2::new(0.0, 0.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, 1.0, 1.0), IVec3::new(-1, 0, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, -0.5, -0.5),
                         texcoord: Vec2::new(1.0, 1.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, -1.0), IVec3::new(-1, 0, 0)),
                     },
                 ],
@@ -482,24 +474,24 @@ fn init_corner_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(0.5, -0.5, -0.5),
                         texcoord: Vec2::new(1.0, 1.0),
                         normal: Vec3A::new(0.0, 1.0, -1.0).normalize(),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, -1.0, -1.0), IVec3::new(0, 0, -1)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, -0.5, -0.5),
                         texcoord: Vec2::new(0.0, 1.0),
                         normal: Vec3A::new(0.0, 1.0, -1.0).normalize(),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, -1.0), IVec3::new(0, 0, -1)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, 0.5, 0.5),
                         texcoord: Vec2::new(0.0, 0.0),
                         normal: Vec3A::new(0.0, 1.0, -1.0).normalize(),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, 1.0, 1.0), IVec3::new(0, 1, 0)),
                     },
                     //
@@ -507,24 +499,24 @@ fn init_corner_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(-0.5, 0.5, 0.5),
                         texcoord: Vec2::new(1.0, 0.0),
                         normal: Vec3A::new(1.0, 1.0, 0.0).normalize(),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, 1.0, 1.0), IVec3::new(0, 1, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(0.5, -0.5, 0.5),
                         texcoord: Vec2::new(1.0, 1.0),
                         normal: Vec3A::new(1.0, 1.0, 0.0).normalize(),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, -1.0, 1.0), IVec3::new(1, 0, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(0.5, -0.5, -0.5),
                         texcoord: Vec2::new(0.0, 1.0),
                         normal: Vec3A::new(1.0, 1.0, 0.0).normalize(),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, -1.0, -1.0), IVec3::new(1, 0, 0)),
                     },
                 ],
@@ -546,24 +538,24 @@ fn init_corner_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(-0.5, 0.5, 0.5),
                         texcoord: Vec2::new(1.0, 1.0),
                         normal: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, 1.0, 1.0), IVec3::new(0, 0, 1)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, -0.5, 0.5),
                         texcoord: Vec2::new(1.0, 0.0),
                         normal: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, 1.0), IVec3::new(0, 0, 1)),
                     },
                     VSVertex {
                         offset: Vec3A::new(0.5, -0.5, 0.5),
                         texcoord: Vec2::new(0.0, 0.0),
                         normal: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, -1.0, 1.0), IVec3::new(0, 0, 1)),
                     },
                 ],
@@ -586,24 +578,24 @@ fn init_inner_corner_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(-0.5, -0.5, 0.5),
                         texcoord: Vec2::new(0.0, 1.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, 1.0), IVec3::new(-1, 0, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, 0.5, -0.5),
                         texcoord: Vec2::new(1.0, 0.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, 1.0, -1.0), IVec3::new(-1, 0, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, -0.5, -0.5),
                         texcoord: Vec2::new(1.0, 1.0),
                         normal: Vec3A::new(-1.0, 0.0, 0.0),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, -1.0), IVec3::new(-1, 0, 0)),
                     },
                 ],
@@ -640,24 +632,24 @@ fn init_inner_corner_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(0.5, 0.5, -0.5),
                         texcoord: Vec2::new(0.0, 0.0),
                         normal: Vec3A::new(0.0, 1.0, 1.0).normalize(),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, 1.0, -1.0), IVec3::new(0, 1, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, 0.5, -0.5),
                         texcoord: Vec2::new(1.0, 0.0),
                         normal: Vec3A::new(0.0, 1.0, 1.0).normalize(),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, 1.0, -1.0), IVec3::new(0, 1, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, -0.5, 0.5),
                         texcoord: Vec2::new(1.0, 1.0),
                         normal: Vec3A::new(0.0, 1.0, 1.0).normalize(),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, 1.0), IVec3::new(0, 0, 0)),
                     },
                     //
@@ -665,24 +657,24 @@ fn init_inner_corner_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(-0.5, -0.5, 0.5),
                         texcoord: Vec2::new(0.0, 1.0),
                         normal: Vec3A::new(-1.0, 1.0, 0.0).normalize(),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, 1.0), IVec3::new(0, 0, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(0.5, 0.5, 0.5),
                         texcoord: Vec2::new(0.0, 0.0),
                         normal: Vec3A::new(-1.0, 1.0, 0.0).normalize(),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, 1.0, 1.0), IVec3::new(0, 1, 0)),
                     },
                     VSVertex {
                         offset: Vec3A::new(0.5, 0.5, -0.5),
                         texcoord: Vec2::new(1.0, 0.0),
                         normal: Vec3A::new(-1.0, 1.0, 0.0).normalize(),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, 1.0, -1.0), IVec3::new(0, 1, 0)),
                     },
                 ],
@@ -708,24 +700,24 @@ fn init_inner_corner_shape() -> VoxelShapeDef {
                         offset: Vec3A::new(0.5, 0.5, 0.5),
                         texcoord: Vec2::new(0.0, 1.0),
                         normal: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, 1.0, 1.0), IVec3::new(0, 0, 1)),
                     },
                     VSVertex {
                         offset: Vec3A::new(-0.5, -0.5, 0.5),
                         texcoord: Vec2::new(1.0, 0.0),
                         normal: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric: Vec3A::new(1.0, 0.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(1.0, 0.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(-1.0, -1.0, 1.0), IVec3::new(0, 0, 1)),
                     },
                     VSVertex {
                         offset: Vec3A::new(0.5, -0.5, 0.5),
                         texcoord: Vec2::new(0.0, 0.0),
                         normal: Vec3A::new(0.0, 0.0, 1.0),
-                        barycentric: Vec3A::new(0.0, 1.0, 0.0),
-                        barycentric_sign: 0,
+                        barycentric: Vec2::new(0.0, 1.0),
+                        barycentric_sign: 0.0,
                         ao_offsets: corner_ao_set(Vec3A::new(1.0, -1.0, 1.0), IVec3::new(0, 0, 1)),
                     },
                 ],

--- a/lib/gs_schemas/src/voxel/voxeltypes.rs
+++ b/lib/gs_schemas/src/voxel/voxeltypes.rs
@@ -2,7 +2,7 @@
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
 
-use rgb::RGBA8;
+use bevy_color::Srgba;
 use serde::{Deserialize, Serialize};
 
 use crate::registry::{Registry, RegistryId, RegistryName, RegistryNameRef, RegistryObject};
@@ -75,7 +75,7 @@ pub struct BlockDefinition {
     /// The set of shapes available
     pub shape_set: BlockShapeSet,
     /// A color that can represent the block on maps, debug views, etc.
-    pub representative_color: RGBA8,
+    pub representative_color: Srgba,
     /// If the block can be collided with
     pub has_collision_box: bool,
     /// If the block has a mesh that can be rendered
@@ -89,7 +89,7 @@ pub const EMPTY_BLOCK_NAME: RegistryName = RegistryName::gs_const("empty");
 pub static EMPTY_BLOCK: BlockDefinition = BlockDefinition {
     name: EMPTY_BLOCK_NAME,
     shape_set: BlockShapeSet::FullCubeOnly,
-    representative_color: RGBA8::new(0, 0, 0, 0),
+    representative_color: bevy_color::palettes::basic::BLACK,
     has_collision_box: false,
     has_drawable_mesh: false,
 };


### PR DESCRIPTION
- Fix a bunch of wrong vectors in the cube shape definition (left-handed -> right-handed coordinate migration)
- Fix broken vector signum function
- Add a custom shader for chunk meshes
- Add back barycentric quad color interpolation using the custom shader
- Clean up some unused code
- Regenerate capnp files with the updated capnpc tool
- Add XYZ gizmo to aid in figuring out directions

![image](https://github.com/user-attachments/assets/60abead7-c86e-4963-a3ea-719d3246a776)
