### PR TITLE
refactor: Make use of async closures to simplify network thread callbacks

### DIFF
--- a/crates/gs_client/src/states/loading_game.rs
+++ b/crates/gs_client/src/states/loading_game.rs
@@ -86,17 +86,15 @@ fn kickoff_game_transition(world: &mut World) {
 
             let net_thread2 = Arc::clone(&net_thread);
             net_thread
-                .schedule_task(|state| {
-                    Box::pin(async move {
-                        let local_conn = server_pipe
-                            .async_wait()
-                            .await
-                            .context("integ_server.create_local_connection")?;
-                        NetworkThreadClientState::connect_locally(state, net_thread2, local_conn)
-                            .await
-                            .context("NetworkThreadClientState::connect_locally")?;
-                        Ok(())
-                    })
+                .schedule_task(async move |state| {
+                    let local_conn = server_pipe
+                        .async_wait()
+                        .await
+                        .context("integ_server.create_local_connection")?;
+                    NetworkThreadClientState::connect_locally(state, net_thread2, local_conn)
+                        .await
+                        .context("NetworkThreadClientState::connect_locally")?;
+                    Ok(())
                 })
                 .blocking_wait()
                 .expect("Could not connect the client to the integrated server");
@@ -115,13 +113,11 @@ fn kickoff_game_transition(world: &mut World) {
             let net_thread2 = Arc::clone(&net_thread);
 
             net_thread
-                .schedule_task(move |state| {
-                    Box::pin(async move {
-                        NetworkThreadClientState::connect_remotely(state, net_thread2, server_address)
-                            .await
-                            .context("NetworkThreadClientState::connect_remotely")?;
-                        Ok(())
-                    })
+                .schedule_task(async move |state| {
+                    NetworkThreadClientState::connect_remotely(state, net_thread2, server_address)
+                        .await
+                        .context("NetworkThreadClientState::connect_remotely")?;
+                    Ok(())
                 })
                 .blocking_wait()
                 .expect("Could not connect the client to the remote server");
@@ -141,30 +137,28 @@ fn kickoff_connected_game_transition(
         registries: GameRegistries,
     }
     let bootstrap_data = authenticated_net_thread
-        .schedule_task(move |state| {
-            Box::pin(async move {
-                assert!(
-                    state.borrow().server_auth_rpc().is_some(),
-                    "Network state was not authenticated before running kickoff_connected_game_transition"
-                );
-                let bootstrap_request = state
-                    .borrow()
-                    .server_auth_rpc()
-                    .context("Missing auth endpoint")?
-                    .bootstrap_game_data_request();
-                let bootstrap_response = bootstrap_request
-                    .send()
-                    .promise
-                    .await
-                    .context("Failed bootstrap request to the remote server")?;
-                let bootstrap_response = bootstrap_response.get()?.get_data()?;
-                let uuid = Uuid::read_from_message(&bootstrap_response.get_universe_id()?);
-                let registries = default_registries.clone_with_serialized_ids(&bootstrap_response)?;
-                let nblocks = registries.block_types.len();
-                info!("Joining server world {uuid} with {nblocks} block types.");
+        .schedule_task(async move |state| {
+            assert!(
+                state.borrow().server_auth_rpc().is_some(),
+                "Network state was not authenticated before running kickoff_connected_game_transition"
+            );
+            let bootstrap_request = state
+                .borrow()
+                .server_auth_rpc()
+                .context("Missing auth endpoint")?
+                .bootstrap_game_data_request();
+            let bootstrap_response = bootstrap_request
+                .send()
+                .promise
+                .await
+                .context("Failed bootstrap request to the remote server")?;
+            let bootstrap_response = bootstrap_response.get()?.get_data()?;
+            let uuid = Uuid::read_from_message(&bootstrap_response.get_universe_id()?);
+            let registries = default_registries.clone_with_serialized_ids(&bootstrap_response)?;
+            let nblocks = registries.block_types.len();
+            info!("Joining server world {uuid} with {nblocks} block types.");
 
-                Ok(NetBootstrap { registries })
-            })
+            Ok(NetBootstrap { registries })
         })
         .blocking_wait()
         .expect("Could not connect the client to the remote server");
@@ -176,16 +170,14 @@ fn kickoff_connected_game_transition(
     let mut promises = world.resource_mut::<LoadingPromiseHolder>();
     promises
         .promises
-        .push(Box::new(authenticated_net_thread.schedule_task(|state| {
-            Box::pin(async move {
-                let auth_rpc = state.borrow().server_auth_rpc().cloned();
-                if let Some(auth_rpc) = auth_rpc {
-                    let mut rq = auth_rpc.send_chat_message_request();
-                    rq.get().set_text("Hello internet networking!");
-                    let _ = rq.send().promise.await;
-                }
-                Ok(())
-            })
+        .push(Box::new(authenticated_net_thread.schedule_task(async move |state| {
+            let auth_rpc = state.borrow().server_auth_rpc().cloned();
+            if let Some(auth_rpc) = auth_rpc {
+                let mut rq = auth_rpc.send_chat_message_request();
+                rq.get().set_text("Hello internet networking!");
+                let _ = rq.send().promise.await;
+            }
+            Ok(())
         })));
 
     let block_registry = Arc::clone(&client_data.shared_registries.block_types);
@@ -205,11 +197,9 @@ fn kickoff_connected_game_transition(
     let mut promises = world.resource_mut::<LoadingPromiseHolder>();
     promises
         .promises
-        .push(Box::new(authenticated_net_thread.schedule_task(|state| {
-            Box::pin(async move {
-                NetworkThreadClientState::allow_streams(state).await;
-                Ok(())
-            })
+        .push(Box::new(authenticated_net_thread.schedule_task(async move |state| {
+            NetworkThreadClientState::allow_streams(state).await;
+            Ok(())
         })));
 }
 

--- a/crates/gs_common/src/lib.rs
+++ b/crates/gs_common/src/lib.rs
@@ -228,8 +228,8 @@ impl GameServer {
     /// Asynchronously creates a new local connection to this server's network runtime.
     pub fn create_local_connection(self: &Arc<Self>) -> AsyncResult<LocalConnectionPipe> {
         let inner_engine = Arc::clone(self);
-        self.network_thread.schedule_task(move |state| {
-            Box::pin(NetworkThreadServerState::accept_local_connection(state, inner_engine))
+        self.network_thread.schedule_task(async move |state| {
+            NetworkThreadServerState::accept_local_connection(state, inner_engine).await
         })
     }
 
@@ -309,12 +309,10 @@ impl GameServer {
         info!("Bootstrapping network");
         engine
             .network_thread
-            .schedule_task(move |state| {
-                Box::pin(async move {
-                    NetworkThreadServerState::bootstrap(state, net_engine).await?;
-                    NetworkThreadServerState::allow_streams(state).await;
-                    Ok(())
-                })
+            .schedule_task(async move |state| {
+                NetworkThreadServerState::bootstrap(state, net_engine).await?;
+                NetworkThreadServerState::allow_streams(state).await;
+                Ok(())
             })
             .blocking_wait()
             .unwrap();

--- a/crates/gs_common/src/network/thread.rs
+++ b/crates/gs_common/src/network/thread.rs
@@ -95,9 +95,7 @@ impl<State: NetworkThreadState> NetworkThread<State> {
 
     /// Schedules a future in the network thread, the future is made using the provided factory function.
     pub fn schedule_task<
-        F: (for<'state> FnOnce(&'state Rc<RefCell<State>>) -> NetworkThreadAsyncFuture<'state, Result<Output>>)
-            + Send
-            + 'static,
+        F: (for<'state> AsyncFnOnce(&'state Rc<RefCell<State>>) -> Result<Output>) + Send + 'static,
         Output: Send + 'static,
     >(
         &self,

--- a/crates/gs_common/src/voxel/plugin.rs
+++ b/crates/gs_common/src/voxel/plugin.rs
@@ -374,62 +374,60 @@ fn send_chunk_to_players(
 
     // TODO: error handling, throttling
     let peers: SmallVec<[_; 8]> = peers.into();
-    let _ = engine.network_thread.schedule_task(move |rstate| {
-        Box::pin(async move {
-            let mut joiner: JoinSet<Result<()>> = JoinSet::new();
-            for addr in peers {
-                let rstate_inner = rstate.clone();
-                let state = rstate.borrow();
-                let my_buffer = buffer.clone();
-                let Some(peer) = state.find_connected_client(addr) else {
-                    bail!("Cannot find connected client {addr:?} anymore");
-                };
-                match &peer.chunk_stream {
-                    Some(chunk_stream) => {
-                        let chunk_stream = chunk_stream.clone();
-                        joiner.spawn_local(async move {
-                            chunk_stream.send(my_buffer).await?;
-                            Ok(())
-                        });
-                    }
-                    None => {
-                        // TODO: encapsulate safe concurrent stream opening
-                        let open_stream = peer.open_stream(NetworkStreamHeader::Standard(StandardTypes::ChunkData));
-                        joiner.spawn_local(async move {
-                            let mut open_stream = open_stream.await?;
-                            {
-                                let mut state = rstate_inner.borrow_mut();
-                                let client = state.find_connected_client_mut(addr).context("Client went missing")?;
-                                if let Some(already_open_stream) = &client.chunk_stream {
-                                    open_stream = already_open_stream.clone();
-                                } else {
-                                    client.chunk_stream = Some(open_stream.clone());
-                                }
+    let _ = engine.network_thread.schedule_task(async move |rstate| {
+        let mut joiner: JoinSet<Result<()>> = JoinSet::new();
+        for addr in peers {
+            let rstate_inner = rstate.clone();
+            let state = rstate.borrow();
+            let my_buffer = buffer.clone();
+            let Some(peer) = state.find_connected_client(addr) else {
+                bail!("Cannot find connected client {addr:?} anymore");
+            };
+            match &peer.chunk_stream {
+                Some(chunk_stream) => {
+                    let chunk_stream = chunk_stream.clone();
+                    joiner.spawn_local(async move {
+                        chunk_stream.send(my_buffer).await?;
+                        Ok(())
+                    });
+                }
+                None => {
+                    // TODO: encapsulate safe concurrent stream opening
+                    let open_stream = peer.open_stream(NetworkStreamHeader::Standard(StandardTypes::ChunkData));
+                    joiner.spawn_local(async move {
+                        let mut open_stream = open_stream.await?;
+                        {
+                            let mut state = rstate_inner.borrow_mut();
+                            let client = state.find_connected_client_mut(addr).context("Client went missing")?;
+                            if let Some(already_open_stream) = &client.chunk_stream {
+                                open_stream = already_open_stream.clone();
+                            } else {
+                                client.chunk_stream = Some(open_stream.clone());
                             }
-                            open_stream.send(my_buffer).await?;
-                            Ok(())
-                        });
-                    }
-                }
-            }
-            while let Some(result) = joiner.join_next().await {
-                match result {
-                    Err(join_error) => {
-                        if join_error.is_cancelled() {
-                            continue;
-                        } else if join_error.is_panic() {
-                            std::panic::resume_unwind(join_error.into_panic())
-                        } else {
-                            unreachable!()
                         }
-                    }
-                    Ok(Err(error)) => {
-                        error!("Error while sending chunk data to player: {error}");
-                    }
-                    Ok(Ok(())) => {}
+                        open_stream.send(my_buffer).await?;
+                        Ok(())
+                    });
                 }
             }
-            Ok(())
-        })
+        }
+        while let Some(result) = joiner.join_next().await {
+            match result {
+                Err(join_error) => {
+                    if join_error.is_cancelled() {
+                        continue;
+                    } else if join_error.is_panic() {
+                        std::panic::resume_unwind(join_error.into_panic())
+                    } else {
+                        unreachable!()
+                    }
+                }
+                Ok(Err(error)) => {
+                    error!("Error while sending chunk data to player: {error}");
+                }
+                Ok(Ok(())) => {}
+            }
+        }
+        Ok(())
     });
 }


### PR DESCRIPTION
Simplifies the code a bit and removes one heap allocation per callback, thanks to rust 1.85.