### PR TITLE
Implement world interaction

### DIFF
--- a/crates/gs_client/src/debugcam.rs
+++ b/crates/gs_client/src/debugcam.rs
@@ -13,7 +13,7 @@ use bevy_egui::EguiContexts;
 use bevy_egui::egui::Align2;
 use gs_common::raycast::{RaycastContext, raycast};
 use gs_common::voxel::plugin::BlockRegistryHolder;
-use gs_schemas::actions::{PositionData, ThrowAction};
+use gs_schemas::actions::{BlockAction, PositionData};
 use gs_schemas::coordinates::{AbsBlockPos, AbsChunkPos, WorldPos};
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
 use gs_schemas::voxel::voxeltypes::EMPTY_BLOCK;
@@ -245,7 +245,7 @@ fn player_action(
                                     offset,
                                     look: transform.forward().into(),
                                 },
-                                ThrowAction::ThrowBlock(),
+                                BlockAction::PlaceBlock(),
                             );
                         } else if button == key_bindings.throw_item {
                             let Vec3 { x, y, z } = transform.translation;
@@ -264,7 +264,7 @@ fn player_action(
                                     offset,
                                     look: transform.forward().into(),
                                 },
-                                ThrowAction::ThrowItem(),
+                                BlockAction::BreakBlock(),
                             );
                         }
                     }

--- a/crates/gs_client/src/debugcam.rs
+++ b/crates/gs_client/src/debugcam.rs
@@ -17,8 +17,9 @@ use gs_schemas::actions::{PositionData, ThrowAction};
 use gs_schemas::coordinates::{AbsBlockPos, AbsChunkPos, WorldPos};
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
 use gs_schemas::voxel::voxeltypes::EMPTY_BLOCK;
+
 use crate::ClientNetworkThreadHolder;
-use crate::states::{in_game, ClientAppState, InGameSystemSet};
+use crate::states::{ClientAppState, InGameSystemSet, in_game};
 use crate::voxel::ClientVoxelUniverse;
 
 /// Mouse sensitivity and movement speed
@@ -237,19 +238,45 @@ fn player_action(
                     _ => {
                         let button = *button;
                         if button == key_bindings.throw_block {
-                            let Vec3 {x, y, z} = transform.translation;
+                            let Vec3 { x, y, z } = transform.translation;
                             let pos = AbsBlockPos::new(x.floor() as i32, y.floor() as i32, z.floor() as i32);
-                            let offset = Vec3 {x: x - pos.x as f32, y: y - pos.y as f32, z: z - pos.z as f32};
-                            in_game::ingame_send_throw_packet(&net_thread, &mut promises, &mut voxels, &bregistry,
-                                                              PositionData {position: pos, offset, look: transform.forward().into() },
-                                                              ThrowAction::ThrowBlock());
+                            let offset = Vec3 {
+                                x: x - pos.x as f32,
+                                y: y - pos.y as f32,
+                                z: z - pos.z as f32,
+                            };
+                            in_game::ingame_send_throw_packet(
+                                &net_thread,
+                                &mut promises,
+                                &mut voxels,
+                                &bregistry,
+                                PositionData {
+                                    position: pos,
+                                    offset,
+                                    look: transform.forward().into(),
+                                },
+                                ThrowAction::ThrowBlock(),
+                            );
                         } else if button == key_bindings.throw_item {
-                            let Vec3 {x, y, z} = transform.translation;
+                            let Vec3 { x, y, z } = transform.translation;
                             let pos = AbsBlockPos::new(x.floor() as i32, y.floor() as i32, z.floor() as i32);
-                            let offset = Vec3 {x: x - pos.x as f32, y: y - pos.y as f32, z: z - pos.z as f32};
-                            in_game::ingame_send_throw_packet(&net_thread, &mut promises, &mut voxels, &bregistry,
-                                                              PositionData {position: pos, offset, look: transform.forward().into() },
-                                                              ThrowAction::ThrowItem());
+                            let offset = Vec3 {
+                                x: x - pos.x as f32,
+                                y: y - pos.y as f32,
+                                z: z - pos.z as f32,
+                            };
+                            in_game::ingame_send_throw_packet(
+                                &net_thread,
+                                &mut promises,
+                                &mut voxels,
+                                &bregistry,
+                                PositionData {
+                                    position: pos,
+                                    offset,
+                                    look: transform.forward().into(),
+                                },
+                                ThrowAction::ThrowItem(),
+                            );
                         }
                     }
                 }

--- a/crates/gs_client/src/debugcam.rs
+++ b/crates/gs_client/src/debugcam.rs
@@ -13,11 +13,12 @@ use bevy_egui::EguiContexts;
 use bevy_egui::egui::Align2;
 use gs_common::raycast::{RaycastContext, raycast};
 use gs_common::voxel::plugin::BlockRegistryHolder;
-use gs_schemas::coordinates::{AbsChunkPos, WorldPos};
+use gs_schemas::actions::{PositionData, ThrowAction};
+use gs_schemas::coordinates::{AbsBlockPos, AbsChunkPos, WorldPos};
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
 use gs_schemas::voxel::voxeltypes::EMPTY_BLOCK;
-
-use crate::states::{ClientAppState, InGameSystemSet};
+use crate::ClientNetworkThreadHolder;
+use crate::states::{in_game, ClientAppState, InGameSystemSet};
 use crate::voxel::ClientVoxelUniverse;
 
 /// Mouse sensitivity and movement speed
@@ -46,6 +47,8 @@ pub struct KeyBindings {
     pub move_ascend: KeyCode,
     pub move_descend: KeyCode,
     pub toggle_grab_cursor: KeyCode,
+    pub throw_block: MouseButton,
+    pub throw_item: MouseButton,
 }
 
 impl Default for KeyBindings {
@@ -58,6 +61,8 @@ impl Default for KeyBindings {
             move_ascend: KeyCode::Space,
             move_descend: KeyCode::ShiftLeft,
             toggle_grab_cursor: KeyCode::Escape,
+            throw_block: MouseButton::Left,
+            throw_item: MouseButton::Right,
         }
     }
 }
@@ -107,7 +112,7 @@ fn setup_player(mut commands: Commands) {
     ));
 }
 
-/// Handles keyboard input and movement
+/// Handles input for movement
 fn player_move(
     keys: Res<ButtonInput<KeyCode>>,
     time: Res<Time>,
@@ -206,6 +211,56 @@ fn player_look(
         }
     } else {
         warn!("Primary window not found for `player_look`!");
+    }
+}
+
+/// Handles input for actions
+fn player_action(
+    net_thread: Res<ClientNetworkThreadHolder>,
+    mut promises: ResMut<in_game::InGamePromiseHolder>,
+    mut voxels: Query<&mut ClientVoxelUniverse>,
+    bregistry: Res<BlockRegistryHolder>,
+    _: Res<ButtonInput<KeyCode>>,
+    mouse: Res<ButtonInput<MouseButton>>,
+    time: Res<Time>,
+    primary_window: Query<&Window, With<PrimaryWindow>>,
+    settings: Res<MovementSettings>,
+    key_bindings: Res<KeyBindings>,
+    mut camera_query: Query<(&FlyCam, &mut Transform)>, //    mut query: Query<&mut Transform, With<FlyCam>>,
+) {
+    if let Ok(window) = primary_window.get_single() {
+        for (_camera, mut transform) in camera_query.iter_mut() {
+            let mut velocity = Vec3::ZERO;
+            for button in mouse.get_just_pressed() {
+                match window.cursor_options.grab_mode {
+                    CursorGrabMode::None => (),
+                    _ => {
+                        let button = *button;
+                        if button == key_bindings.throw_block {
+                            let Vec3 {x, y, z} = transform.translation;
+                            let pos = AbsBlockPos::new(x.floor() as i32, y.floor() as i32, z.floor() as i32);
+                            let offset = Vec3 {x: x - pos.x as f32, y: y - pos.y as f32, z: z - pos.z as f32};
+                            in_game::ingame_send_throw_packet(&net_thread, &mut promises, &mut voxels, &bregistry,
+                                                              PositionData {position: pos, offset, look: transform.forward().into() },
+                                                              ThrowAction::ThrowBlock());
+                        } else if button == key_bindings.throw_item {
+                            let Vec3 {x, y, z} = transform.translation;
+                            let pos = AbsBlockPos::new(x.floor() as i32, y.floor() as i32, z.floor() as i32);
+                            let offset = Vec3 {x: x - pos.x as f32, y: y - pos.y as f32, z: z - pos.z as f32};
+                            in_game::ingame_send_throw_packet(&net_thread, &mut promises, &mut voxels, &bregistry,
+                                                              PositionData {position: pos, offset, look: transform.forward().into() },
+                                                              ThrowAction::ThrowItem());
+                        }
+                    }
+                }
+
+                velocity = velocity.normalize_or_zero();
+
+                transform.translation += velocity * time.delta_secs() * settings.speed;
+            }
+        }
+    } else {
+        warn!("Primary window not found for `player_action`!");
     }
 }
 
@@ -406,12 +461,14 @@ impl Plugin for PlayerPlugin {
             .add_systems(OnEnter(ClientAppState::InGame), spawn_debug_text)
             .add_systems(Update, player_move.in_set(InGameSystemSet))
             .add_systems(Update, player_look.in_set(InGameSystemSet))
+            .add_systems(Update, player_action.in_set(InGameSystemSet))
             .add_systems(
                 Update,
                 (gizmo_toggles, xyz_gizmo, cur_chunk_gizmo, lookat_gizmo)
                     .in_set(InGameSystemSet)
                     .after(player_move)
-                    .after(player_look),
+                    .after(player_look)
+                    .after(player_action),
             )
             .add_systems(Update, cursor_grab.in_set(InGameSystemSet));
     }

--- a/crates/gs_client/src/debugcam.rs
+++ b/crates/gs_client/src/debugcam.rs
@@ -218,38 +218,28 @@ fn player_look(
 /// Handles input for actions
 fn player_action(
     net_thread: Res<ClientNetworkThreadHolder>,
-    mut promises: ResMut<in_game::InGamePromiseHolder>,
     mut voxels: Query<&mut ClientVoxelUniverse>,
-    bregistry: Res<BlockRegistryHolder>,
+    block_reg: Res<BlockRegistryHolder>,
     _: Res<ButtonInput<KeyCode>>,
     mouse: Res<ButtonInput<MouseButton>>,
-    time: Res<Time>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
-    settings: Res<MovementSettings>,
     key_bindings: Res<KeyBindings>,
     mut camera_query: Query<(&FlyCam, &mut Transform)>, //    mut query: Query<&mut Transform, With<FlyCam>>,
 ) {
     if let Ok(window) = primary_window.get_single() {
-        for (_camera, mut transform) in camera_query.iter_mut() {
-            let mut velocity = Vec3::ZERO;
-            for button in mouse.get_just_pressed() {
+        for (_camera, transform) in camera_query.iter_mut() {
+            for &button in mouse.get_just_pressed() {
                 match window.cursor_options.grab_mode {
                     CursorGrabMode::None => (),
                     _ => {
-                        let button = *button;
                         if button == key_bindings.throw_block {
-                            let Vec3 { x, y, z } = transform.translation;
-                            let pos = AbsBlockPos::new(x.floor() as i32, y.floor() as i32, z.floor() as i32);
-                            let offset = Vec3 {
-                                x: x - pos.x as f32,
-                                y: y - pos.y as f32,
-                                z: z - pos.z as f32,
-                            };
+                            let pos = transform.translation.floor();
+                            let offset = transform.translation - pos;
+                            let pos = AbsBlockPos::from_ivec3(pos.as_ivec3());
                             in_game::ingame_send_throw_packet(
                                 &net_thread,
-                                &mut promises,
                                 &mut voxels,
-                                &bregistry,
+                                &block_reg,
                                 PositionData {
                                     position: pos,
                                     offset,
@@ -267,9 +257,8 @@ fn player_action(
                             };
                             in_game::ingame_send_throw_packet(
                                 &net_thread,
-                                &mut promises,
                                 &mut voxels,
-                                &bregistry,
+                                &block_reg,
                                 PositionData {
                                     position: pos,
                                     offset,
@@ -280,10 +269,6 @@ fn player_action(
                         }
                     }
                 }
-
-                velocity = velocity.normalize_or_zero();
-
-                transform.translation += velocity * time.delta_secs() * settings.speed;
             }
         }
     } else {
@@ -393,19 +378,19 @@ fn lookat_gizmo(
     let Some(bregistry) = bregistry else {
         return;
     };
-    let rcctx = RaycastContext {
+    let ray_ctx = RaycastContext {
         block_registry: Some(&bregistry),
         voxel_world: Some(voxels),
     };
     let camera_zero: Vec3A = camera.transform_point(Vec3::ZERO).into();
-    let rcspec = RaycastSpec {
+    let ray_spec = RaycastSpec {
         start: WorldPos::from_vec3(camera_zero),
         direction: camera.forward().into(),
         distance_limit: limit,
         hit_mask: RaycastHitMask::all(),
     };
 
-    let rc = raycast(&rcctx, &rcspec);
+    let rc = raycast(&ray_ctx, &ray_spec);
     let RaycastResult::BlockHit(rc) = rc else {
         let limit_sphere = camera.transform_point(vec3(0.0, 0.0, -limit));
         gizmos.sphere(limit_sphere, 0.5, tailwind::RED_600);

--- a/crates/gs_client/src/states/in_game.rs
+++ b/crates/gs_client/src/states/in_game.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use gs_common::raycast::{RaycastContext, raycast};
 use gs_common::voxel::blocks::STONE_BLOCK_NAME;
 use gs_common::voxel::plugin::BlockRegistryHolder;
-use gs_schemas::actions::{PositionData, ThrowAction};
+use gs_schemas::actions::{BlockAction, PositionData};
 use gs_schemas::coordinates::WorldPos;
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
 use gs_schemas::voxel::chunk_storage::ChunkStorage;
@@ -33,14 +33,14 @@ pub(crate) fn ingame_send_throw_packet(
     voxel_query: &mut Query<&mut ClientVoxelUniverse>,
     block_reg: &Res<BlockRegistryHolder>,
     position: PositionData,
-    throw: ThrowAction,
+    action: BlockAction,
 ) {
     let _ = net_thread.0.schedule_task(async move |state| {
         let auth_rpc = state.borrow().server_auth_rpc().cloned();
         if let Some(auth_rpc) = auth_rpc {
-            let mut rq = auth_rpc.send_throw_action_request();
+            let mut rq = auth_rpc.send_block_action_request();
             position.to_builder(&mut rq.get().init_position());
-            throw.to_builder(&mut rq.get().init_throw());
+            action.to_builder(&mut rq.get().init_action());
             rq.get().set_tick(0); // TODO send the actual client tick
             let _ = rq.send().promise.await;
         }
@@ -66,7 +66,7 @@ pub(crate) fn ingame_send_throw_packet(
     let RaycastResult::BlockHit(rc) = rc else {
         return;
     };
-    let pos = if let ThrowAction::ThrowBlock() = throw {
+    let pos = if let BlockAction::PlaceBlock() = action {
         rc.position.direction_offset(rc.face, 1)
     } else {
         rc.position
@@ -76,11 +76,11 @@ pub(crate) fn ingame_send_throw_packet(
 
     let (chunk, local) = pos.split_chunk_component();
     if let Some(chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {
-        match throw {
-            ThrowAction::ThrowBlock() => {
+        match action {
+            BlockAction::PlaceBlock() => {
                 chunk.mutate_predicted().blocks.put(local, BlockEntry::new(i_stone, 0));
             }
-            ThrowAction::ThrowItem() => {
+            BlockAction::BreakBlock() => {
                 chunk.mutate_predicted().blocks.put(local, BlockEntry::new(i_empty, 0));
             }
         }

--- a/crates/gs_client/src/states/in_game.rs
+++ b/crates/gs_client/src/states/in_game.rs
@@ -3,13 +3,11 @@
 use bevy::prelude::*;
 use gs_common::prelude::GenericAsyncResult;
 use gs_common::raycast::{raycast, RaycastContext};
-use gs_common::ServerData;
 use gs_common::voxel::blocks::STONE_BLOCK_NAME;
-use gs_common::voxel::plugin::{BlockRegistryHolder, VoxelUniverse};
+use gs_common::voxel::plugin::BlockRegistryHolder;
 use gs_schemas::actions::{PositionData, ThrowAction};
 use gs_schemas::coordinates::WorldPos;
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
-use gs_schemas::schemas::game_types_capnp::position_data;
 use gs_schemas::voxel::chunk_storage::ChunkStorage;
 use gs_schemas::voxel::voxeltypes::{BlockEntry, EMPTY_BLOCK_NAME};
 use crate::ClientNetworkThreadHolder;
@@ -55,7 +53,7 @@ pub(crate) fn ingame_send_throw_packet(net_thread: &Res<ClientNetworkThreadHolde
         return;
     };
     let rcctx = RaycastContext {
-        block_registry: Some(&bregistry),
+        block_registry: Some(bregistry),
         voxel_world: Some(voxels),
     };
     let rcspec = RaycastSpec {
@@ -78,7 +76,7 @@ pub(crate) fn ingame_send_throw_packet(net_thread: &Res<ClientNetworkThreadHolde
     let (i_empty, _) = bregistry.lookup_name_to_object(EMPTY_BLOCK_NAME.as_ref()).unwrap();
 
     let (chunk, local) = pos.split_chunk_component();
-    if let Some(mut chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {
+    if let Some(chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {
         match throw {
             ThrowAction::ThrowBlock() => {
                 chunk.mutate_predicted().blocks.put(local, BlockEntry::new(i_stone, 0));

--- a/crates/gs_client/src/states/in_game.rs
+++ b/crates/gs_client/src/states/in_game.rs
@@ -2,7 +2,7 @@
 
 use bevy::prelude::*;
 use gs_common::prelude::GenericAsyncResult;
-use gs_common::raycast::{raycast, RaycastContext};
+use gs_common::raycast::{RaycastContext, raycast};
 use gs_common::voxel::blocks::STONE_BLOCK_NAME;
 use gs_common::voxel::plugin::BlockRegistryHolder;
 use gs_schemas::actions::{PositionData, ThrowAction};
@@ -10,6 +10,7 @@ use gs_schemas::coordinates::WorldPos;
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
 use gs_schemas::voxel::chunk_storage::ChunkStorage;
 use gs_schemas::voxel::voxeltypes::{BlockEntry, EMPTY_BLOCK_NAME};
+
 use crate::ClientNetworkThreadHolder;
 use crate::states::ClientAppState;
 use crate::voxel::ClientVoxelUniverse;
@@ -34,7 +35,14 @@ fn ingame_cleanup_on_exit(net_thread: ResMut<ClientNetworkThreadHolder>) {
 }
 
 /// sends a throw packet over the given net thread and promise holder
-pub(crate) fn ingame_send_throw_packet(net_thread: &Res<ClientNetworkThreadHolder>,  promises: &mut ResMut<InGamePromiseHolder>, voxel_query: &mut Query<&mut ClientVoxelUniverse>, bregistry: &Res<BlockRegistryHolder>, position: PositionData, throw: ThrowAction) {
+pub(crate) fn ingame_send_throw_packet(
+    net_thread: &Res<ClientNetworkThreadHolder>,
+    promises: &mut ResMut<InGamePromiseHolder>,
+    voxel_query: &mut Query<&mut ClientVoxelUniverse>,
+    bregistry: &Res<BlockRegistryHolder>,
+    position: PositionData,
+    throw: ThrowAction,
+) {
     promises
         .promises
         .push(Box::new(net_thread.0.schedule_task(async move |state| {
@@ -47,7 +55,7 @@ pub(crate) fn ingame_send_throw_packet(net_thread: &Res<ClientNetworkThreadHolde
             }
             Ok(())
         })));
-    
+
     let limit = 64.0;
     let Ok(voxels) = &mut voxel_query.get_single_mut() else {
         return;

--- a/crates/gs_client/src/states/in_game.rs
+++ b/crates/gs_client/src/states/in_game.rs
@@ -1,19 +1,91 @@
 //! The state for when the player is in game, with all basic gameplay resources fully loaded.
 
 use bevy::prelude::*;
-
+use gs_common::prelude::GenericAsyncResult;
+use gs_common::raycast::{raycast, RaycastContext};
+use gs_common::ServerData;
+use gs_common::voxel::blocks::STONE_BLOCK_NAME;
+use gs_common::voxel::plugin::{BlockRegistryHolder, VoxelUniverse};
+use gs_schemas::actions::{PositionData, ThrowAction};
+use gs_schemas::coordinates::WorldPos;
+use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
+use gs_schemas::schemas::game_types_capnp::position_data;
+use gs_schemas::voxel::chunk_storage::ChunkStorage;
+use gs_schemas::voxel::voxeltypes::{BlockEntry, EMPTY_BLOCK_NAME};
 use crate::ClientNetworkThreadHolder;
 use crate::states::ClientAppState;
+use crate::voxel::ClientVoxelUniverse;
 
 /// The "plugin" implementing the in game state.
 pub struct InGamePlugin;
 
 impl Plugin for InGamePlugin {
     fn build(&self, app: &mut App) {
+        app.init_resource::<InGamePromiseHolder>();
         app.add_systems(OnExit(ClientAppState::InGame), ingame_cleanup_on_exit);
     }
 }
 
+#[derive(Resource, Default)]
+pub(crate) struct InGamePromiseHolder {
+    promises: Vec<Box<dyn GenericAsyncResult + Send + Sync>>,
+}
+
 fn ingame_cleanup_on_exit(net_thread: ResMut<ClientNetworkThreadHolder>) {
     net_thread.0.sync_shutdown();
+}
+
+/// sends a throw packet over the given net thread and promise holder
+pub(crate) fn ingame_send_throw_packet(net_thread: &Res<ClientNetworkThreadHolder>,  promises: &mut ResMut<InGamePromiseHolder>, voxel_query: &mut Query<&mut ClientVoxelUniverse>, bregistry: &Res<BlockRegistryHolder>, position: PositionData, throw: ThrowAction) {
+    promises
+        .promises
+        .push(Box::new(net_thread.0.schedule_task(async move |state| {
+            let auth_rpc = state.borrow().server_auth_rpc().cloned();
+            if let Some(auth_rpc) = auth_rpc {
+                let mut rq = auth_rpc.send_throw_action_request();
+                position.to_builder(&mut rq.get().init_position());
+                throw.to_builder(&mut rq.get().init_throw());
+                let _ = rq.send().promise.await;
+            }
+            Ok(())
+        })));
+    
+    let limit = 64.0;
+    let Ok(voxels) = &mut voxel_query.get_single_mut() else {
+        return;
+    };
+    let rcctx = RaycastContext {
+        block_registry: Some(&bregistry),
+        voxel_world: Some(voxels),
+    };
+    let rcspec = RaycastSpec {
+        start: WorldPos::from_offset(position.position, position.offset.into()),
+        direction: Dir3::new(position.look).unwrap().into(),
+        distance_limit: limit,
+        hit_mask: RaycastHitMask::all(),
+    };
+
+    let rc = raycast(&rcctx, &rcspec);
+    let RaycastResult::BlockHit(rc) = rc else {
+        return;
+    };
+    let pos = if let ThrowAction::ThrowBlock() = throw {
+        rc.face.offset(&rc.position, 1)
+    } else {
+        rc.position
+    };
+    let (i_stone, _) = bregistry.lookup_name_to_object(STONE_BLOCK_NAME.as_ref()).unwrap();
+    let (i_empty, _) = bregistry.lookup_name_to_object(EMPTY_BLOCK_NAME.as_ref()).unwrap();
+
+    let (chunk, local) = pos.split_chunk_component();
+    if let Some(mut chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {
+        match throw {
+            ThrowAction::ThrowBlock() => {
+                chunk.mutate_predicted().blocks.put(local, BlockEntry::new(i_stone, 0));
+            }
+            ThrowAction::ThrowItem() => {
+                chunk.mutate_predicted().blocks.put(local, BlockEntry::new(i_empty, 0));
+            }
+        }
+    }
 }

--- a/crates/gs_client/src/states/in_game.rs
+++ b/crates/gs_client/src/states/in_game.rs
@@ -1,7 +1,6 @@
 //! The state for when the player is in game, with all basic gameplay resources fully loaded.
 
 use bevy::prelude::*;
-use gs_common::prelude::GenericAsyncResult;
 use gs_common::raycast::{RaycastContext, raycast};
 use gs_common::voxel::blocks::STONE_BLOCK_NAME;
 use gs_common::voxel::plugin::BlockRegistryHolder;
@@ -20,14 +19,8 @@ pub struct InGamePlugin;
 
 impl Plugin for InGamePlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<InGamePromiseHolder>();
         app.add_systems(OnExit(ClientAppState::InGame), ingame_cleanup_on_exit);
     }
-}
-
-#[derive(Resource, Default)]
-pub(crate) struct InGamePromiseHolder {
-    promises: Vec<Box<dyn GenericAsyncResult + Send + Sync>>,
 }
 
 fn ingame_cleanup_on_exit(net_thread: ResMut<ClientNetworkThreadHolder>) {
@@ -37,51 +30,48 @@ fn ingame_cleanup_on_exit(net_thread: ResMut<ClientNetworkThreadHolder>) {
 /// sends a throw packet over the given net thread and promise holder
 pub(crate) fn ingame_send_throw_packet(
     net_thread: &Res<ClientNetworkThreadHolder>,
-    promises: &mut ResMut<InGamePromiseHolder>,
     voxel_query: &mut Query<&mut ClientVoxelUniverse>,
-    bregistry: &Res<BlockRegistryHolder>,
+    block_reg: &Res<BlockRegistryHolder>,
     position: PositionData,
     throw: ThrowAction,
 ) {
-    promises
-        .promises
-        .push(Box::new(net_thread.0.schedule_task(async move |state| {
-            let auth_rpc = state.borrow().server_auth_rpc().cloned();
-            if let Some(auth_rpc) = auth_rpc {
-                let mut rq = auth_rpc.send_throw_action_request();
-                position.to_builder(&mut rq.get().init_position());
-                throw.to_builder(&mut rq.get().init_throw());
-                let _ = rq.send().promise.await;
-            }
-            Ok(())
-        })));
+    let _ = net_thread.0.schedule_task(async move |state| {
+        let auth_rpc = state.borrow().server_auth_rpc().cloned();
+        if let Some(auth_rpc) = auth_rpc {
+            let mut rq = auth_rpc.send_throw_action_request();
+            position.to_builder(&mut rq.get().init_position());
+            throw.to_builder(&mut rq.get().init_throw());
+            let _ = rq.send().promise.await;
+        }
+        Ok(())
+    });
 
     let limit = 64.0;
     let Ok(voxels) = &mut voxel_query.get_single_mut() else {
         return;
     };
-    let rcctx = RaycastContext {
-        block_registry: Some(bregistry),
+    let ray_ctx = RaycastContext {
+        block_registry: Some(block_reg),
         voxel_world: Some(voxels),
     };
-    let rcspec = RaycastSpec {
-        start: WorldPos::from_offset(position.position, position.offset.into()),
+    let ray_spec = RaycastSpec {
+        start: WorldPos::from_offset_blockpos(position.position, position.offset.into()),
         direction: Dir3::new(position.look).unwrap().into(),
         distance_limit: limit,
         hit_mask: RaycastHitMask::all(),
     };
 
-    let rc = raycast(&rcctx, &rcspec);
+    let rc = raycast(&ray_ctx, &ray_spec);
     let RaycastResult::BlockHit(rc) = rc else {
         return;
     };
     let pos = if let ThrowAction::ThrowBlock() = throw {
-        rc.face.offset(&rc.position, 1)
+        rc.position.direction_offset(rc.face, 1)
     } else {
         rc.position
     };
-    let (i_stone, _) = bregistry.lookup_name_to_object(STONE_BLOCK_NAME.as_ref()).unwrap();
-    let (i_empty, _) = bregistry.lookup_name_to_object(EMPTY_BLOCK_NAME.as_ref()).unwrap();
+    let (i_stone, _) = block_reg.lookup_name_to_object(STONE_BLOCK_NAME.as_ref()).unwrap();
+    let (i_empty, _) = block_reg.lookup_name_to_object(EMPTY_BLOCK_NAME.as_ref()).unwrap();
 
     let (chunk, local) = pos.split_chunk_component();
     if let Some(chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {

--- a/crates/gs_client/src/states/in_game.rs
+++ b/crates/gs_client/src/states/in_game.rs
@@ -41,6 +41,7 @@ pub(crate) fn ingame_send_throw_packet(
             let mut rq = auth_rpc.send_throw_action_request();
             position.to_builder(&mut rq.get().init_position());
             throw.to_builder(&mut rq.get().init_throw());
+            rq.get().set_tick(0); // TODO send the actual client tick
             let _ = rq.send().promise.await;
         }
         Ok(())

--- a/crates/gs_common/src/network/server.rs
+++ b/crates/gs_common/src/network/server.rs
@@ -7,7 +7,6 @@ use bevy::ecs::component::{ComponentHooks, StorageType};
 use bevy::ecs::world::DeferredWorld;
 use bevy::log;
 use bevy::prelude::*;
-use bevy_math::{vec3, Vec3A};
 use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::{RpcSystem, pry};
 use futures::FutureExt;
@@ -24,8 +23,7 @@ use tokio::task::{JoinHandle, JoinSet, spawn_local};
 use tracing::Instrument;
 use uuid::Uuid;
 use gs_schemas::actions::{PositionData, ThrowAction};
-use gs_schemas::coordinates::{AbsChunkPos, WorldPos};
-use gs_schemas::dependencies::bevy_color::palettes::tailwind;
+use gs_schemas::coordinates::WorldPos;
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
 use gs_schemas::voxel::chunk_storage::ChunkStorage;
 use gs_schemas::voxel::voxeltypes::{BlockEntry, EMPTY_BLOCK_NAME};
@@ -662,7 +660,7 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
                 return Ok(());
             };
             let rcctx = RaycastContext {
-                block_registry: Some(&bregistry),
+                block_registry: Some(bregistry),
                 voxel_world: Some(voxels),
             };
             let rcspec = RaycastSpec {
@@ -689,7 +687,7 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
             let Ok(voxels) = &mut voxel_query.get_single_mut(world) else {
                 return Ok(());
             };
-            if let Some(mut chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {
+            if let Some(chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {
                 match throw {
                     ThrowAction::ThrowBlock() => {
                         chunk.mutate_stored().blocks.put(local, BlockEntry::new(i_stone, 0));

--- a/crates/gs_common/src/network/server.rs
+++ b/crates/gs_common/src/network/server.rs
@@ -7,6 +7,7 @@ use bevy::ecs::component::{ComponentHooks, StorageType};
 use bevy::ecs::world::DeferredWorld;
 use bevy::log;
 use bevy::prelude::*;
+use bevy_math::{vec3, Vec3A};
 use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::{RpcSystem, pry};
 use futures::FutureExt;
@@ -14,9 +15,7 @@ use futures::future::BoxFuture;
 use gs_schemas::dependencies::capnp::Error;
 use gs_schemas::dependencies::capnp::capability::Promise;
 use gs_schemas::dependencies::kstring::KString;
-use gs_schemas::schemas::network_capnp::authenticated_server_connection::{
-    BootstrapGameDataParams, BootstrapGameDataResults, SendChatMessageParams, SendChatMessageResults,
-};
+use gs_schemas::schemas::network_capnp::authenticated_server_connection::{BootstrapGameDataParams, BootstrapGameDataResults, SendChatMessageParams, SendChatMessageResults, SendThrowActionParams, SendThrowActionResults};
 use gs_schemas::schemas::{NetworkStreamHeader, SchemaUuidExt, network_capnp as rpc};
 use quinn::{Connection, EndpointConfig};
 use socket2::{Domain, Socket};
@@ -24,7 +23,12 @@ use tokio::select;
 use tokio::task::{JoinHandle, JoinSet, spawn_local};
 use tracing::Instrument;
 use uuid::Uuid;
-
+use gs_schemas::actions::{PositionData, ThrowAction};
+use gs_schemas::coordinates::{AbsChunkPos, WorldPos};
+use gs_schemas::dependencies::bevy_color::palettes::tailwind;
+use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
+use gs_schemas::voxel::chunk_storage::ChunkStorage;
+use gs_schemas::voxel::voxeltypes::{BlockEntry, EMPTY_BLOCK_NAME};
 use crate::network::PeerAddress;
 use crate::network::thread::NetworkThreadState;
 use crate::network::transport::{
@@ -33,9 +37,10 @@ use crate::network::transport::{
 };
 use crate::prelude::*;
 use crate::promises::ShutdownHandle;
-use crate::{
-    GAME_VERSION_BUILD, GAME_VERSION_MAJOR, GAME_VERSION_MINOR, GAME_VERSION_PATCH, GAME_VERSION_PRERELEASE, GameServer,
-};
+use crate::{GAME_VERSION_BUILD, GAME_VERSION_MAJOR, GAME_VERSION_MINOR, GAME_VERSION_PATCH, GAME_VERSION_PRERELEASE, GameServer, ServerData};
+use crate::raycast::{raycast, RaycastContext};
+use crate::voxel::blocks::STONE_BLOCK_NAME;
+use crate::voxel::plugin::{BlockRegistryHolder, VoxelUniverse};
 
 /// The network thread game server state, accessible from network functions.
 pub struct NetworkThreadServerState {
@@ -630,6 +635,72 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
             self.0.borrow().peer,
             text
         );
+        Promise::ok(())
+    }
+
+    fn send_throw_action(&mut self, params: SendThrowActionParams, _: SendThrowActionResults) -> Promise<(), Error> {
+        let params = pry!(params.get());
+        let position: PositionData = pry!(params.get_position()).try_into().unwrap();
+        let throw: ThrowAction = pry!(params.get_throw()).try_into().unwrap();
+        info!(
+            "Client {} ({:?}) sent a throw packet `{:?}`, `{:?}`",
+            self.0.borrow().username,
+            self.0.borrow().peer,
+            position,
+            throw
+        );
+        let _ = self.0.borrow().server.schedule_bevy(move |world| {
+            let mut voxel_query = world.query::<&VoxelUniverse<ServerData>>();
+            let bregistry = {
+                &world.get_resource::<BlockRegistryHolder>()
+            };
+            let limit = 64.0;
+            let Ok(voxels) = &voxel_query.get_single(world) else {
+                return Ok(());
+            };
+            let Some(bregistry) = bregistry else {
+                return Ok(());
+            };
+            let rcctx = RaycastContext {
+                block_registry: Some(&bregistry),
+                voxel_world: Some(voxels),
+            };
+            let rcspec = RaycastSpec {
+                start: WorldPos::from_offset(position.position, position.offset.into()),
+                direction: Dir3::new(position.look).unwrap().into(),
+                distance_limit: limit,
+                hit_mask: RaycastHitMask::all(),
+            };
+
+            let rc = raycast(&rcctx, &rcspec);
+            let RaycastResult::BlockHit(rc) = rc else {
+                return Ok(());
+            };
+            let pos = if let ThrowAction::ThrowBlock() = throw {
+                rc.face.offset(&rc.position, 1)
+            } else {
+                rc.position
+            };
+            let (i_stone, _) = bregistry.lookup_name_to_object(STONE_BLOCK_NAME.as_ref()).unwrap();
+            let (i_empty, _) = bregistry.lookup_name_to_object(EMPTY_BLOCK_NAME.as_ref()).unwrap();
+
+            let (chunk, local) = pos.split_chunk_component();
+            let mut voxel_query = world.query::<&mut VoxelUniverse<ServerData>>();
+            let Ok(voxels) = &mut voxel_query.get_single_mut(world) else {
+                return Ok(());
+            };
+            if let Some(mut chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {
+                match throw {
+                    ThrowAction::ThrowBlock() => {
+                        chunk.mutate_stored().blocks.put(local, BlockEntry::new(i_stone, 0));
+                    }
+                    ThrowAction::ThrowItem() => {
+                        chunk.mutate_stored().blocks.put(local, BlockEntry::new(i_empty, 0));
+                    }
+                }
+            }
+            Ok(())
+        });
         Promise::ok(())
     }
 }

--- a/crates/gs_common/src/network/server.rs
+++ b/crates/gs_common/src/network/server.rs
@@ -11,18 +11,17 @@ use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::{RpcSystem, pry};
 use futures::FutureExt;
 use futures::future::BoxFuture;
-use gs_schemas::actions::{PositionData, ThrowAction};
-use gs_schemas::capnp_adapters::{adapt_i_vec3, adapt_throw_action, adapt_vec3};
+use gs_schemas::actions::{BlockAction, PositionData};
+use gs_schemas::capnp_adapters::{adapt_block_action, adapt_i_vec3, adapt_vec3};
 use gs_schemas::coordinates::WorldPos;
 use gs_schemas::dependencies::capnp::Error;
 use gs_schemas::dependencies::capnp::capability::Promise;
 use gs_schemas::dependencies::kstring::KString;
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
-use gs_schemas::schemas::game_types_capnp::throw_action::WhichReader;
-use gs_schemas::schemas::game_types_capnp::{i_vec3, throw_action};
+use gs_schemas::schemas::game_types_capnp::i_vec3;
 use gs_schemas::schemas::network_capnp::authenticated_server_connection::{
-    BootstrapGameDataParams, BootstrapGameDataResults, SendChatMessageParams, SendChatMessageResults,
-    SendThrowActionParams, SendThrowActionResults,
+    BootstrapGameDataParams, BootstrapGameDataResults, SendBlockActionParams, SendBlockActionResults,
+    SendChatMessageParams, SendChatMessageResults,
 };
 use gs_schemas::schemas::{NetworkStreamHeader, SchemaUuidExt, network_capnp as rpc};
 use gs_schemas::voxel::chunk_storage::ChunkStorage;
@@ -646,18 +645,18 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
         Promise::ok(())
     }
 
-    fn send_throw_action(&mut self, params: SendThrowActionParams, _: SendThrowActionResults) -> Promise<(), Error> {
+    fn send_block_action(&mut self, params: SendBlockActionParams, _: SendBlockActionResults) -> Promise<(), Error> {
         let params = pry!(params.get());
         let position = pry!(params.get_position());
         // have to adapt because Readers can't be sent across threads,
         // and schedule_bevy counts as one.
-        let throw = adapt_throw_action(pry!(params.get_throw())).unwrap();
+        let action = adapt_block_action(pry!(params.get_action())).unwrap();
         info!(
             "Client {} ({:?}) sent a throw packet `{:?}`, `{:?}`",
             self.0.borrow().username,
             self.0.borrow().peer,
             position,
-            throw
+            action
         );
         let ray_spec = RaycastSpec {
             start: WorldPos::from_offset_blockpos(
@@ -688,7 +687,7 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
             let RaycastResult::BlockHit(rc) = rc else {
                 return Ok(());
             };
-            let pos = if let ThrowAction::ThrowBlock() = throw {
+            let pos = if let BlockAction::PlaceBlock() = action {
                 rc.position.direction_offset(rc.face, 1)
             } else {
                 rc.position
@@ -702,11 +701,11 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
                 return Ok(());
             };
             if let Some(chunk) = voxels.loaded_chunks_mut().get_chunk_mut(chunk) {
-                match throw {
-                    ThrowAction::ThrowBlock() => {
+                match action {
+                    BlockAction::PlaceBlock() => {
                         chunk.mutate_stored().blocks.put(local, BlockEntry::new(i_stone, 0));
                     }
-                    ThrowAction::ThrowItem() => {
+                    BlockAction::BreakBlock() => {
                         chunk.mutate_stored().blocks.put(local, BlockEntry::new(i_empty, 0));
                     }
                 }

--- a/crates/gs_common/src/network/server.rs
+++ b/crates/gs_common/src/network/server.rs
@@ -11,22 +11,26 @@ use capnp_rpc::rpc_twoparty_capnp::Side;
 use capnp_rpc::{RpcSystem, pry};
 use futures::FutureExt;
 use futures::future::BoxFuture;
+use gs_schemas::actions::{PositionData, ThrowAction};
+use gs_schemas::coordinates::WorldPos;
 use gs_schemas::dependencies::capnp::Error;
 use gs_schemas::dependencies::capnp::capability::Promise;
 use gs_schemas::dependencies::kstring::KString;
-use gs_schemas::schemas::network_capnp::authenticated_server_connection::{BootstrapGameDataParams, BootstrapGameDataResults, SendChatMessageParams, SendChatMessageResults, SendThrowActionParams, SendThrowActionResults};
+use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
+use gs_schemas::schemas::network_capnp::authenticated_server_connection::{
+    BootstrapGameDataParams, BootstrapGameDataResults, SendChatMessageParams, SendChatMessageResults,
+    SendThrowActionParams, SendThrowActionResults,
+};
 use gs_schemas::schemas::{NetworkStreamHeader, SchemaUuidExt, network_capnp as rpc};
+use gs_schemas::voxel::chunk_storage::ChunkStorage;
+use gs_schemas::voxel::voxeltypes::{BlockEntry, EMPTY_BLOCK_NAME};
 use quinn::{Connection, EndpointConfig};
 use socket2::{Domain, Socket};
 use tokio::select;
 use tokio::task::{JoinHandle, JoinSet, spawn_local};
 use tracing::Instrument;
 use uuid::Uuid;
-use gs_schemas::actions::{PositionData, ThrowAction};
-use gs_schemas::coordinates::WorldPos;
-use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
-use gs_schemas::voxel::chunk_storage::ChunkStorage;
-use gs_schemas::voxel::voxeltypes::{BlockEntry, EMPTY_BLOCK_NAME};
+
 use crate::network::PeerAddress;
 use crate::network::thread::NetworkThreadState;
 use crate::network::transport::{
@@ -35,10 +39,13 @@ use crate::network::transport::{
 };
 use crate::prelude::*;
 use crate::promises::ShutdownHandle;
-use crate::{GAME_VERSION_BUILD, GAME_VERSION_MAJOR, GAME_VERSION_MINOR, GAME_VERSION_PATCH, GAME_VERSION_PRERELEASE, GameServer, ServerData};
-use crate::raycast::{raycast, RaycastContext};
+use crate::raycast::{RaycastContext, raycast};
 use crate::voxel::blocks::STONE_BLOCK_NAME;
 use crate::voxel::plugin::{BlockRegistryHolder, VoxelUniverse};
+use crate::{
+    GAME_VERSION_BUILD, GAME_VERSION_MAJOR, GAME_VERSION_MINOR, GAME_VERSION_PATCH, GAME_VERSION_PRERELEASE,
+    GameServer, ServerData,
+};
 
 /// The network thread game server state, accessible from network functions.
 pub struct NetworkThreadServerState {
@@ -649,9 +656,7 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
         );
         let _ = self.0.borrow().server.schedule_bevy(move |world| {
             let mut voxel_query = world.query::<&VoxelUniverse<ServerData>>();
-            let bregistry = {
-                &world.get_resource::<BlockRegistryHolder>()
-            };
+            let bregistry = { &world.get_resource::<BlockRegistryHolder>() };
             let limit = 64.0;
             let Ok(voxels) = &voxel_query.get_single(world) else {
                 return Ok(());

--- a/crates/gs_common/src/network/server.rs
+++ b/crates/gs_common/src/network/server.rs
@@ -12,11 +12,14 @@ use capnp_rpc::{RpcSystem, pry};
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use gs_schemas::actions::{PositionData, ThrowAction};
+use gs_schemas::capnp_adapters::{adapt_i_vec3, adapt_throw_action, adapt_vec3};
 use gs_schemas::coordinates::WorldPos;
 use gs_schemas::dependencies::capnp::Error;
 use gs_schemas::dependencies::capnp::capability::Promise;
 use gs_schemas::dependencies::kstring::KString;
 use gs_schemas::raycast::{RaycastHitMask, RaycastResult, RaycastSpec};
+use gs_schemas::schemas::game_types_capnp::throw_action::WhichReader;
+use gs_schemas::schemas::game_types_capnp::{i_vec3, throw_action};
 use gs_schemas::schemas::network_capnp::authenticated_server_connection::{
     BootstrapGameDataParams, BootstrapGameDataResults, SendChatMessageParams, SendChatMessageResults,
     SendThrowActionParams, SendThrowActionResults,
@@ -645,8 +648,10 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
 
     fn send_throw_action(&mut self, params: SendThrowActionParams, _: SendThrowActionResults) -> Promise<(), Error> {
         let params = pry!(params.get());
-        let position: PositionData = pry!(params.get_position()).try_into().unwrap();
-        let throw: ThrowAction = pry!(params.get_throw()).try_into().unwrap();
+        let position = pry!(params.get_position());
+        // have to adapt because Readers can't be sent across threads,
+        // and schedule_bevy counts as one.
+        let throw = adapt_throw_action(pry!(params.get_throw())).unwrap();
         info!(
             "Client {} ({:?}) sent a throw packet `{:?}`, `{:?}`",
             self.0.borrow().username,
@@ -654,33 +659,37 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
             position,
             throw
         );
+        let ray_spec = RaycastSpec {
+            start: WorldPos::from_offset_blockpos(
+                adapt_i_vec3(position.get_position().unwrap()).into(),
+                adapt_vec3(position.get_offset().unwrap()).into(),
+            ),
+            direction: Dir3::new(adapt_vec3(position.get_look().unwrap()).into())
+                .unwrap()
+                .into(),
+            distance_limit: 64.0,
+            hit_mask: RaycastHitMask::all(),
+        };
         let _ = self.0.borrow().server.schedule_bevy(move |world| {
             let mut voxel_query = world.query::<&VoxelUniverse<ServerData>>();
-            let bregistry = { &world.get_resource::<BlockRegistryHolder>() };
-            let limit = 64.0;
+            let block_reg = { &world.get_resource::<BlockRegistryHolder>() };
             let Ok(voxels) = &voxel_query.get_single(world) else {
                 return Ok(());
             };
-            let Some(bregistry) = bregistry else {
+            let Some(bregistry) = block_reg else {
                 return Ok(());
             };
-            let rcctx = RaycastContext {
+            let ray_ctx = RaycastContext {
                 block_registry: Some(bregistry),
                 voxel_world: Some(voxels),
             };
-            let rcspec = RaycastSpec {
-                start: WorldPos::from_offset(position.position, position.offset.into()),
-                direction: Dir3::new(position.look).unwrap().into(),
-                distance_limit: limit,
-                hit_mask: RaycastHitMask::all(),
-            };
 
-            let rc = raycast(&rcctx, &rcspec);
+            let rc = raycast(&ray_ctx, &ray_spec);
             let RaycastResult::BlockHit(rc) = rc else {
                 return Ok(());
             };
             let pos = if let ThrowAction::ThrowBlock() = throw {
-                rc.face.offset(&rc.position, 1)
+                rc.position.direction_offset(rc.face, 1)
             } else {
                 rc.position
             };

--- a/lib/gs_schemas/capnp-generated/game_types_capnp.rs
+++ b/lib/gs_schemas/capnp-generated/game_types_capnp.rs
@@ -3985,3 +3985,929 @@ pub mod full_chunk_data {
     pub const TYPE_ID: u64 = 0x8ef7_cfc1_8954_654c;
   }
 }
+
+pub mod position_data {
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
+  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  impl <> ::core::marker::Copy for Reader<'_,>  {}
+  impl <> ::core::clone::Clone for Reader<'_,>  {
+    fn clone(&self) -> Self { *self }
+  }
+
+  impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
+    const TYPE_ID: u64 = _private::TYPE_ID;
+  }
+  impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
+    fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+      Self { reader,  }
+    }
+  }
+
+  impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
+    fn from(reader: Reader<'a,>) -> Self {
+      Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    }
+  }
+
+  impl <> ::core::fmt::Debug for Reader<'_,>  {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
+      core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+      ::core::result::Result::Ok(reader.get_struct(default)?.into())
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> Reader<'a,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Self { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn get_position(self) -> ::capnp::Result<crate::schemas::game_types_capnp::i_vec3::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_position(&self) -> bool {
+      !self.reader.get_pointer_field(0).is_null()
+    }
+    #[inline]
+    pub fn get_offset(self) -> ::capnp::Result<crate::schemas::game_types_capnp::vec3::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_offset(&self) -> bool {
+      !self.reader.get_pointer_field(1).is_null()
+    }
+    #[inline]
+    pub fn get_look(self) -> ::capnp::Result<crate::schemas::game_types_capnp::vec3::Reader<'a>> {
+      ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(2), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn has_look(&self) -> bool {
+      !self.reader.get_pointer_field(2).is_null()
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 3 };
+  }
+  impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
+    const TYPE_ID: u64 = _private::TYPE_ID;
+  }
+  impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
+    fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+      Self { builder,  }
+    }
+  }
+
+  impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
+    fn from(builder: Builder<'a,>) -> Self {
+      Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+      builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+      ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
+    }
+  }
+
+  impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      self.builder.into_reader().into()
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { builder: self.builder.reborrow() }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      self.builder.as_reader().into()
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.as_reader().total_size()
+    }
+    #[inline]
+    pub fn get_position(self) -> ::capnp::Result<crate::schemas::game_types_capnp::i_vec3::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_position(&mut self, value: crate::schemas::game_types_capnp::i_vec3::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
+    }
+    #[inline]
+    pub fn init_position(self, ) -> crate::schemas::game_types_capnp::i_vec3::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+    }
+    #[inline]
+    pub fn has_position(&self) -> bool {
+      !self.builder.is_pointer_field_null(0)
+    }
+    #[inline]
+    pub fn get_offset(self) -> ::capnp::Result<crate::schemas::game_types_capnp::vec3::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_offset(&mut self, value: crate::schemas::game_types_capnp::vec3::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(1), value, false)
+    }
+    #[inline]
+    pub fn init_offset(self, ) -> crate::schemas::game_types_capnp::vec3::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
+    }
+    #[inline]
+    pub fn has_offset(&self) -> bool {
+      !self.builder.is_pointer_field_null(1)
+    }
+    #[inline]
+    pub fn get_look(self) -> ::capnp::Result<crate::schemas::game_types_capnp::vec3::Builder<'a>> {
+      ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(2), ::core::option::Option::None)
+    }
+    #[inline]
+    pub fn set_look(&mut self, value: crate::schemas::game_types_capnp::vec3::Reader<'_>) -> ::capnp::Result<()> {
+      ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(2), value, false)
+    }
+    #[inline]
+    pub fn init_look(self, ) -> crate::schemas::game_types_capnp::vec3::Builder<'a> {
+      ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(2), 0)
+    }
+    #[inline]
+    pub fn has_look(&self) -> bool {
+      !self.builder.is_pointer_field_null(2)
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+      Self { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+    pub fn get_position(&self) -> crate::schemas::game_types_capnp::i_vec3::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+    }
+    pub fn get_offset(&self) -> crate::schemas::game_types_capnp::vec3::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
+    }
+    pub fn get_look(&self) -> crate::schemas::game_types_capnp::vec3::Pipeline {
+      ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(2))
+    }
+  }
+  mod _private {
+    pub static ENCODED_NODE: [::capnp::Word; 65] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
+      ::capnp::word(224, 249, 178, 196, 42, 142, 176, 165),
+      ::capnp::word(17, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
+      ::capnp::word(3, 0, 7, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(86, 8, 0, 0, 173, 8, 0, 0),
+      ::capnp::word(21, 0, 0, 0, 242, 0, 0, 0),
+      ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(29, 0, 0, 0, 175, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(103, 97, 109, 101, 95, 116, 121, 112),
+      ::capnp::word(101, 115, 46, 99, 97, 112, 110, 112),
+      ::capnp::word(58, 80, 111, 115, 105, 116, 105, 111),
+      ::capnp::word(110, 68, 97, 116, 97, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(69, 0, 0, 0, 74, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(68, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(80, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(77, 0, 0, 0, 58, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(2, 0, 0, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(81, 0, 0, 0, 42, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(76, 0, 0, 0, 3, 0, 1, 0),
+      ::capnp::word(88, 0, 0, 0, 2, 0, 1, 0),
+      ::capnp::word(112, 111, 115, 105, 116, 105, 111, 110),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(142, 136, 96, 220, 125, 236, 86, 134),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(111, 102, 102, 115, 101, 116, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(192, 225, 96, 132, 199, 180, 105, 237),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(108, 111, 111, 107, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(192, 225, 96, 132, 199, 180, 105, 237),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+    ];
+    pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+      match index {
+        0 => <crate::schemas::game_types_capnp::i_vec3::Owned as ::capnp::introspect::Introspect>::introspect(),
+        1 => <crate::schemas::game_types_capnp::vec3::Owned as ::capnp::introspect::Introspect>::introspect(),
+        2 => <crate::schemas::game_types_capnp::vec3::Owned as ::capnp::introspect::Introspect>::introspect(),
+        _ => panic!("invalid field index {}", index),
+      }
+    }
+    pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
+      panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+    }
+    pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
+      encoded_node: &ENCODED_NODE,
+      nonunion_members: NONUNION_MEMBERS,
+      members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+      members_by_name: MEMBERS_BY_NAME,
+    };
+    pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
+    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
+    pub static MEMBERS_BY_NAME : &[u16] = &[2,1,0];
+    pub const TYPE_ID: u64 = 0xa5b0_8e2a_c4b2_f9e0;
+  }
+}
+
+pub mod throw_action {
+  pub use self::Which::{ThrowBlock,ThrowItem};
+
+  #[derive(Copy, Clone)]
+  pub struct Owned(());
+  impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
+  impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+  impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+  pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+  impl <> ::core::marker::Copy for Reader<'_,>  {}
+  impl <> ::core::clone::Clone for Reader<'_,>  {
+    fn clone(&self) -> Self { *self }
+  }
+
+  impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
+    const TYPE_ID: u64 = _private::TYPE_ID;
+  }
+  impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
+    fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+      Self { reader,  }
+    }
+  }
+
+  impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
+    fn from(reader: Reader<'a,>) -> Self {
+      Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    }
+  }
+
+  impl <> ::core::fmt::Debug for Reader<'_,>  {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
+      core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+    fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+      ::core::result::Result::Ok(reader.get_struct(default)?.into())
+    }
+  }
+
+  impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+    fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+      self.reader
+    }
+  }
+
+  impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+    fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+      self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> Reader<'a,>  {
+    pub fn reborrow(&self) -> Reader<'_,> {
+      Self { .. *self }
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.reader.total_size()
+    }
+    #[inline]
+    pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
+      match self.reader.get_data_field::<u16>(0) {
+        0 => {
+          ::core::result::Result::Ok(ThrowBlock(
+            self.reader.into()
+          ))
+        }
+        1 => {
+          ::core::result::Result::Ok(ThrowItem(
+            self.reader.into()
+          ))
+        }
+        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+      }
+    }
+  }
+
+  pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+  impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
+    const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 0 };
+  }
+  impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
+    const TYPE_ID: u64 = _private::TYPE_ID;
+  }
+  impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
+    fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+      Self { builder,  }
+    }
+  }
+
+  impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
+    fn from(builder: Builder<'a,>) -> Self {
+      Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+    fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+      self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+    }
+  }
+
+  impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+    fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+      builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
+    }
+    fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+      ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
+    }
+  }
+
+  impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
+    fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+  }
+
+  impl <'a,> Builder<'a,>  {
+    pub fn into_reader(self) -> Reader<'a,> {
+      self.builder.into_reader().into()
+    }
+    pub fn reborrow(&mut self) -> Builder<'_,> {
+      Builder { builder: self.builder.reborrow() }
+    }
+    pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+      self.builder.as_reader().into()
+    }
+
+    pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+      self.builder.as_reader().total_size()
+    }
+    #[inline]
+    pub fn init_throw_block(self, ) -> crate::schemas::game_types_capnp::throw_action::throw_block::Builder<'a> {
+      self.builder.set_data_field::<u16>(0, 0);
+      self.builder.into()
+    }
+    #[inline]
+    pub fn init_throw_item(self, ) -> crate::schemas::game_types_capnp::throw_action::throw_item::Builder<'a> {
+      self.builder.set_data_field::<u16>(0, 1);
+      self.builder.into()
+    }
+    #[inline]
+    pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
+      match self.builder.get_data_field::<u16>(0) {
+        0 => {
+          ::core::result::Result::Ok(ThrowBlock(
+            self.builder.into()
+          ))
+        }
+        1 => {
+          ::core::result::Result::Ok(ThrowItem(
+            self.builder.into()
+          ))
+        }
+        x => ::core::result::Result::Err(::capnp::NotInSchema(x))
+      }
+    }
+  }
+
+  pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+  impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+    fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+      Self { _typeless: typeless,  }
+    }
+  }
+  impl Pipeline  {
+  }
+  mod _private {
+    pub static ENCODED_NODE: [::capnp::Word; 37] = [
+      ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
+      ::capnp::word(155, 58, 165, 109, 213, 129, 125, 200),
+      ::capnp::word(17, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
+      ::capnp::word(0, 0, 7, 0, 0, 0, 2, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(175, 8, 0, 0, 92, 9, 0, 0),
+      ::capnp::word(21, 0, 0, 0, 234, 0, 0, 0),
+      ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(29, 0, 0, 0, 119, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(103, 97, 109, 101, 95, 116, 121, 112),
+      ::capnp::word(101, 115, 46, 99, 97, 112, 110, 112),
+      ::capnp::word(58, 84, 104, 114, 111, 119, 65, 99),
+      ::capnp::word(116, 105, 111, 110, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
+      ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
+      ::capnp::word(0, 0, 255, 255, 0, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(225, 219, 73, 38, 86, 112, 128, 197),
+      ::capnp::word(41, 0, 0, 0, 90, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(1, 0, 254, 255, 0, 0, 0, 0),
+      ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(105, 2, 82, 110, 32, 121, 20, 211),
+      ::capnp::word(21, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(116, 104, 114, 111, 119, 66, 108, 111),
+      ::capnp::word(99, 107, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(116, 104, 114, 111, 119, 73, 116, 101),
+      ::capnp::word(109, 0, 0, 0, 0, 0, 0, 0),
+    ];
+    pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+      match index {
+        0 => <crate::schemas::game_types_capnp::throw_action::throw_block::Owned as ::capnp::introspect::Introspect>::introspect(),
+        1 => <crate::schemas::game_types_capnp::throw_action::throw_item::Owned as ::capnp::introspect::Introspect>::introspect(),
+        _ => panic!("invalid field index {}", index),
+      }
+    }
+    pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
+      panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+    }
+    pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
+      encoded_node: &ENCODED_NODE,
+      nonunion_members: NONUNION_MEMBERS,
+      members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+      members_by_name: MEMBERS_BY_NAME,
+    };
+    pub static NONUNION_MEMBERS : &[u16] = &[];
+    pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[0,1];
+    pub static MEMBERS_BY_NAME : &[u16] = &[0,1];
+    pub const TYPE_ID: u64 = 0xc87d_81d5_6da5_3a9b;
+  }
+  pub enum Which<A0,A1> {
+    ThrowBlock(A0),
+    ThrowItem(A1),
+  }
+  pub type WhichReader<'a,> = Which<crate::schemas::game_types_capnp::throw_action::throw_block::Reader<'a>,crate::schemas::game_types_capnp::throw_action::throw_item::Reader<'a>>;
+  pub type WhichBuilder<'a,> = Which<crate::schemas::game_types_capnp::throw_action::throw_block::Builder<'a>,crate::schemas::game_types_capnp::throw_action::throw_item::Builder<'a>>;
+
+  pub mod throw_block {
+    #[derive(Copy, Clone)]
+    pub struct Owned(());
+    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
+    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    impl <> ::core::marker::Copy for Reader<'_,>  {}
+    impl <> ::core::clone::Clone for Reader<'_,>  {
+      fn clone(&self) -> Self { *self }
+    }
+
+    impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
+      const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
+      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+        Self { reader,  }
+      }
+    }
+
+    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
+      fn from(reader: Reader<'a,>) -> Self {
+        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+      }
+    }
+
+    impl <> ::core::fmt::Debug for Reader<'_,>  {
+      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
+        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+        ::core::result::Result::Ok(reader.get_struct(default)?.into())
+      }
+    }
+
+    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+        self.reader
+      }
+    }
+
+    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+      }
+    }
+
+    impl <> Reader<'_,>  {
+      pub fn reborrow(&self) -> Reader<'_,> {
+        Self { .. *self }
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.reader.total_size()
+      }
+      #[inline]
+      pub fn get_unused(self)  {
+        
+      }
+    }
+
+    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+    impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 0 };
+    }
+    impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
+      const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
+      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+        Self { builder,  }
+      }
+    }
+
+    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
+      fn from(builder: Builder<'a,>) -> Self {
+        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
+      }
+      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
+      }
+    }
+
+    impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    }
+
+    impl <'a,> Builder<'a,>  {
+      pub fn into_reader(self) -> Reader<'a,> {
+        self.builder.into_reader().into()
+      }
+      pub fn reborrow(&mut self) -> Builder<'_,> {
+        Builder { builder: self.builder.reborrow() }
+      }
+      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+        self.builder.as_reader().into()
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.builder.as_reader().total_size()
+      }
+      #[inline]
+      pub fn get_unused(self)  {
+        
+      }
+      #[inline]
+      pub fn set_unused(&mut self, _value: ())  {
+      }
+    }
+
+    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+        Self { _typeless: typeless,  }
+      }
+    }
+    impl Pipeline  {
+    }
+    mod _private {
+      pub static ENCODED_NODE: [::capnp::Word; 34] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
+        ::capnp::word(225, 219, 73, 38, 86, 112, 128, 197),
+        ::capnp::word(29, 0, 0, 0, 1, 0, 1, 0),
+        ::capnp::word(155, 58, 165, 109, 213, 129, 125, 200),
+        ::capnp::word(0, 0, 7, 0, 1, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(21, 0, 0, 0, 66, 1, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(29, 0, 0, 0, 63, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(103, 97, 109, 101, 95, 116, 121, 112),
+        ::capnp::word(101, 115, 46, 99, 97, 112, 110, 112),
+        ::capnp::word(58, 84, 104, 114, 111, 119, 65, 99),
+        ::capnp::word(116, 105, 111, 110, 46, 116, 104, 114),
+        ::capnp::word(111, 119, 66, 108, 111, 99, 107, 0),
+        ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(13, 0, 0, 0, 58, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(117, 110, 117, 115, 101, 100, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ];
+      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+        match index {
+          0 => <() as ::capnp::introspect::Introspect>::introspect(),
+          _ => panic!("invalid field index {}", index),
+        }
+      }
+      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
+        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+      }
+      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
+        encoded_node: &ENCODED_NODE,
+        nonunion_members: NONUNION_MEMBERS,
+        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+        members_by_name: MEMBERS_BY_NAME,
+      };
+      pub static NONUNION_MEMBERS : &[u16] = &[0];
+      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
+      pub static MEMBERS_BY_NAME : &[u16] = &[0];
+      pub const TYPE_ID: u64 = 0xc580_7056_2649_dbe1;
+    }
+  }
+
+  pub mod throw_item {
+    #[derive(Copy, Clone)]
+    pub struct Owned(());
+    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
+    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    impl <> ::core::marker::Copy for Reader<'_,>  {}
+    impl <> ::core::clone::Clone for Reader<'_,>  {
+      fn clone(&self) -> Self { *self }
+    }
+
+    impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
+      const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
+      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+        Self { reader,  }
+      }
+    }
+
+    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
+      fn from(reader: Reader<'a,>) -> Self {
+        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+      }
+    }
+
+    impl <> ::core::fmt::Debug for Reader<'_,>  {
+      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
+        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+        ::core::result::Result::Ok(reader.get_struct(default)?.into())
+      }
+    }
+
+    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+        self.reader
+      }
+    }
+
+    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+      }
+    }
+
+    impl <> Reader<'_,>  {
+      pub fn reborrow(&self) -> Reader<'_,> {
+        Self { .. *self }
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.reader.total_size()
+      }
+      #[inline]
+      pub fn get_unused(self)  {
+        
+      }
+    }
+
+    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+    impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 0 };
+    }
+    impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
+      const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
+      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+        Self { builder,  }
+      }
+    }
+
+    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
+      fn from(builder: Builder<'a,>) -> Self {
+        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
+      }
+      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
+      }
+    }
+
+    impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    }
+
+    impl <'a,> Builder<'a,>  {
+      pub fn into_reader(self) -> Reader<'a,> {
+        self.builder.into_reader().into()
+      }
+      pub fn reborrow(&mut self) -> Builder<'_,> {
+        Builder { builder: self.builder.reborrow() }
+      }
+      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+        self.builder.as_reader().into()
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.builder.as_reader().total_size()
+      }
+      #[inline]
+      pub fn get_unused(self)  {
+        
+      }
+      #[inline]
+      pub fn set_unused(&mut self, _value: ())  {
+      }
+    }
+
+    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+        Self { _typeless: typeless,  }
+      }
+    }
+    impl Pipeline  {
+    }
+    mod _private {
+      pub static ENCODED_NODE: [::capnp::Word; 34] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
+        ::capnp::word(105, 2, 82, 110, 32, 121, 20, 211),
+        ::capnp::word(29, 0, 0, 0, 1, 0, 1, 0),
+        ::capnp::word(155, 58, 165, 109, 213, 129, 125, 200),
+        ::capnp::word(0, 0, 7, 0, 1, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(21, 0, 0, 0, 58, 1, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(29, 0, 0, 0, 63, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(103, 97, 109, 101, 95, 116, 121, 112),
+        ::capnp::word(101, 115, 46, 99, 97, 112, 110, 112),
+        ::capnp::word(58, 84, 104, 114, 111, 119, 65, 99),
+        ::capnp::word(116, 105, 111, 110, 46, 116, 104, 114),
+        ::capnp::word(111, 119, 73, 116, 101, 109, 0, 0),
+        ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(13, 0, 0, 0, 58, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(8, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(20, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(117, 110, 117, 115, 101, 100, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ];
+      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+        match index {
+          0 => <() as ::capnp::introspect::Introspect>::introspect(),
+          _ => panic!("invalid field index {}", index),
+        }
+      }
+      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
+        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+      }
+      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
+        encoded_node: &ENCODED_NODE,
+        nonunion_members: NONUNION_MEMBERS,
+        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+        members_by_name: MEMBERS_BY_NAME,
+      };
+      pub static NONUNION_MEMBERS : &[u16] = &[0];
+      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
+      pub static MEMBERS_BY_NAME : &[u16] = &[0];
+      pub const TYPE_ID: u64 = 0xd314_7920_6e52_0269;
+    }
+  }
+}

--- a/lib/gs_schemas/capnp-generated/game_types_capnp.rs
+++ b/lib/gs_schemas/capnp-generated/game_types_capnp.rs
@@ -4284,8 +4284,8 @@ pub mod position_data {
   }
 }
 
-pub mod throw_action {
-  pub use self::Which::{ThrowBlock,ThrowItem};
+pub mod block_action {
+  pub use self::Which::{PlaceBlock,BreakBlock};
 
   #[derive(Copy, Clone)]
   pub struct Owned(());
@@ -4351,12 +4351,12 @@ pub mod throw_action {
     pub fn which(self) -> ::core::result::Result<WhichReader<'a,>, ::capnp::NotInSchema> {
       match self.reader.get_data_field::<u16>(0) {
         0 => {
-          ::core::result::Result::Ok(ThrowBlock(
+          ::core::result::Result::Ok(PlaceBlock(
             self.reader.into()
           ))
         }
         1 => {
-          ::core::result::Result::Ok(ThrowItem(
+          ::core::result::Result::Ok(BreakBlock(
             self.reader.into()
           ))
         }
@@ -4418,12 +4418,12 @@ pub mod throw_action {
       self.builder.as_reader().total_size()
     }
     #[inline]
-    pub fn init_throw_block(self, ) -> crate::schemas::game_types_capnp::throw_action::throw_block::Builder<'a> {
+    pub fn init_place_block(self, ) -> crate::schemas::game_types_capnp::block_action::place_block::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 0);
       self.builder.into()
     }
     #[inline]
-    pub fn init_throw_item(self, ) -> crate::schemas::game_types_capnp::throw_action::throw_item::Builder<'a> {
+    pub fn init_break_block(self, ) -> crate::schemas::game_types_capnp::block_action::break_block::Builder<'a> {
       self.builder.set_data_field::<u16>(0, 1);
       self.builder.into()
     }
@@ -4431,12 +4431,12 @@ pub mod throw_action {
     pub fn which(self) -> ::core::result::Result<WhichBuilder<'a,>, ::capnp::NotInSchema> {
       match self.builder.get_data_field::<u16>(0) {
         0 => {
-          ::core::result::Result::Ok(ThrowBlock(
+          ::core::result::Result::Ok(PlaceBlock(
             self.builder.into()
           ))
         }
         1 => {
-          ::core::result::Result::Ok(ThrowItem(
+          ::core::result::Result::Ok(BreakBlock(
             self.builder.into()
           ))
         }
@@ -4456,12 +4456,12 @@ pub mod throw_action {
   mod _private {
     pub static ENCODED_NODE: [::capnp::Word; 37] = [
       ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
-      ::capnp::word(155, 58, 165, 109, 213, 129, 125, 200),
+      ::capnp::word(114, 249, 128, 56, 240, 42, 102, 129),
       ::capnp::word(17, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(76, 179, 72, 237, 196, 148, 233, 165),
       ::capnp::word(0, 0, 7, 0, 0, 0, 2, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(175, 8, 0, 0, 92, 9, 0, 0),
+      ::capnp::word(175, 8, 0, 0, 192, 9, 0, 0),
       ::capnp::word(21, 0, 0, 0, 234, 0, 0, 0),
       ::capnp::word(33, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -4470,33 +4470,33 @@ pub mod throw_action {
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(103, 97, 109, 101, 95, 116, 121, 112),
       ::capnp::word(101, 115, 46, 99, 97, 112, 110, 112),
-      ::capnp::word(58, 84, 104, 114, 111, 119, 65, 99),
+      ::capnp::word(58, 66, 108, 111, 99, 107, 65, 99),
       ::capnp::word(116, 105, 111, 110, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 1, 0, 1, 0),
       ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
       ::capnp::word(0, 0, 255, 255, 0, 0, 0, 0),
       ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(225, 219, 73, 38, 86, 112, 128, 197),
+      ::capnp::word(166, 66, 239, 122, 70, 87, 20, 152),
       ::capnp::word(41, 0, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(1, 0, 254, 255, 0, 0, 0, 0),
       ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(105, 2, 82, 110, 32, 121, 20, 211),
-      ::capnp::word(21, 0, 0, 0, 82, 0, 0, 0),
+      ::capnp::word(229, 210, 106, 137, 7, 131, 107, 139),
+      ::capnp::word(21, 0, 0, 0, 90, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(116, 104, 114, 111, 119, 66, 108, 111),
+      ::capnp::word(112, 108, 97, 99, 101, 66, 108, 111),
       ::capnp::word(99, 107, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(116, 104, 114, 111, 119, 73, 116, 101),
-      ::capnp::word(109, 0, 0, 0, 0, 0, 0, 0),
+      ::capnp::word(98, 114, 101, 97, 107, 66, 108, 111),
+      ::capnp::word(99, 107, 0, 0, 0, 0, 0, 0),
     ];
     pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
       match index {
-        0 => <crate::schemas::game_types_capnp::throw_action::throw_block::Owned as ::capnp::introspect::Introspect>::introspect(),
-        1 => <crate::schemas::game_types_capnp::throw_action::throw_item::Owned as ::capnp::introspect::Introspect>::introspect(),
+        0 => <crate::schemas::game_types_capnp::block_action::place_block::Owned as ::capnp::introspect::Introspect>::introspect(),
+        1 => <crate::schemas::game_types_capnp::block_action::break_block::Owned as ::capnp::introspect::Introspect>::introspect(),
         _ => panic!("invalid field index {}", index),
       }
     }
@@ -4511,17 +4511,17 @@ pub mod throw_action {
     };
     pub static NONUNION_MEMBERS : &[u16] = &[];
     pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[0,1];
-    pub static MEMBERS_BY_NAME : &[u16] = &[0,1];
-    pub const TYPE_ID: u64 = 0xc87d_81d5_6da5_3a9b;
+    pub static MEMBERS_BY_NAME : &[u16] = &[1,0];
+    pub const TYPE_ID: u64 = 0x8166_2af0_3880_f972;
   }
   pub enum Which<A0,A1> {
-    ThrowBlock(A0),
-    ThrowItem(A1),
+    PlaceBlock(A0),
+    BreakBlock(A1),
   }
-  pub type WhichReader<'a,> = Which<crate::schemas::game_types_capnp::throw_action::throw_block::Reader<'a>,crate::schemas::game_types_capnp::throw_action::throw_item::Reader<'a>>;
-  pub type WhichBuilder<'a,> = Which<crate::schemas::game_types_capnp::throw_action::throw_block::Builder<'a>,crate::schemas::game_types_capnp::throw_action::throw_item::Builder<'a>>;
+  pub type WhichReader<'a,> = Which<crate::schemas::game_types_capnp::block_action::place_block::Reader<'a>,crate::schemas::game_types_capnp::block_action::break_block::Reader<'a>>;
+  pub type WhichBuilder<'a,> = Which<crate::schemas::game_types_capnp::block_action::place_block::Builder<'a>,crate::schemas::game_types_capnp::block_action::break_block::Builder<'a>>;
 
-  pub mod throw_block {
+  pub mod place_block {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
@@ -4660,9 +4660,9 @@ pub mod throw_action {
     mod _private {
       pub static ENCODED_NODE: [::capnp::Word; 34] = [
         ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
-        ::capnp::word(225, 219, 73, 38, 86, 112, 128, 197),
+        ::capnp::word(166, 66, 239, 122, 70, 87, 20, 152),
         ::capnp::word(29, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(155, 58, 165, 109, 213, 129, 125, 200),
+        ::capnp::word(114, 249, 128, 56, 240, 42, 102, 129),
         ::capnp::word(0, 0, 7, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -4674,9 +4674,9 @@ pub mod throw_action {
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(103, 97, 109, 101, 95, 116, 121, 112),
         ::capnp::word(101, 115, 46, 99, 97, 112, 110, 112),
-        ::capnp::word(58, 84, 104, 114, 111, 119, 65, 99),
-        ::capnp::word(116, 105, 111, 110, 46, 116, 104, 114),
-        ::capnp::word(111, 119, 66, 108, 111, 99, 107, 0),
+        ::capnp::word(58, 66, 108, 111, 99, 107, 65, 99),
+        ::capnp::word(116, 105, 111, 110, 46, 112, 108, 97),
+        ::capnp::word(99, 101, 66, 108, 111, 99, 107, 0),
         ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
@@ -4712,11 +4712,11 @@ pub mod throw_action {
       pub static NONUNION_MEMBERS : &[u16] = &[0];
       pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
       pub static MEMBERS_BY_NAME : &[u16] = &[0];
-      pub const TYPE_ID: u64 = 0xc580_7056_2649_dbe1;
+      pub const TYPE_ID: u64 = 0x9814_5746_7aef_42a6;
     }
   }
 
-  pub mod throw_item {
+  pub mod break_block {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
@@ -4855,13 +4855,13 @@ pub mod throw_action {
     mod _private {
       pub static ENCODED_NODE: [::capnp::Word; 34] = [
         ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
-        ::capnp::word(105, 2, 82, 110, 32, 121, 20, 211),
+        ::capnp::word(229, 210, 106, 137, 7, 131, 107, 139),
         ::capnp::word(29, 0, 0, 0, 1, 0, 1, 0),
-        ::capnp::word(155, 58, 165, 109, 213, 129, 125, 200),
+        ::capnp::word(114, 249, 128, 56, 240, 42, 102, 129),
         ::capnp::word(0, 0, 7, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(21, 0, 0, 0, 58, 1, 0, 0),
+        ::capnp::word(21, 0, 0, 0, 66, 1, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(29, 0, 0, 0, 63, 0, 0, 0),
@@ -4869,9 +4869,9 @@ pub mod throw_action {
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(103, 97, 109, 101, 95, 116, 121, 112),
         ::capnp::word(101, 115, 46, 99, 97, 112, 110, 112),
-        ::capnp::word(58, 84, 104, 114, 111, 119, 65, 99),
-        ::capnp::word(116, 105, 111, 110, 46, 116, 104, 114),
-        ::capnp::word(111, 119, 73, 116, 101, 109, 0, 0),
+        ::capnp::word(58, 66, 108, 111, 99, 107, 65, 99),
+        ::capnp::word(116, 105, 111, 110, 46, 98, 114, 101),
+        ::capnp::word(97, 107, 66, 108, 111, 99, 107, 0),
         ::capnp::word(4, 0, 0, 0, 3, 0, 4, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
@@ -4907,7 +4907,7 @@ pub mod throw_action {
       pub static NONUNION_MEMBERS : &[u16] = &[0];
       pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
       pub static MEMBERS_BY_NAME : &[u16] = &[0];
-      pub const TYPE_ID: u64 = 0xd314_7920_6e52_0269;
+      pub const TYPE_ID: u64 = 0x8b6b_8307_896a_d2e5;
     }
   }
 }

--- a/lib/gs_schemas/capnp-generated/network_capnp.rs
+++ b/lib/gs_schemas/capnp-generated/network_capnp.rs
@@ -3601,8 +3601,8 @@ pub mod authenticated_server_connection {
   pub type BootstrapGameDataResults<> = ::capnp::capability::Results<crate::schemas::network_capnp::authenticated_server_connection::bootstrap_game_data_results::Owned>;
   pub type SendChatMessageParams<> = ::capnp::capability::Params<crate::schemas::network_capnp::authenticated_server_connection::send_chat_message_params::Owned>;
   pub type SendChatMessageResults<> = ::capnp::capability::Results<crate::schemas::network_capnp::authenticated_server_connection::send_chat_message_results::Owned>;
-  pub type SendThrowActionParams<> = ::capnp::capability::Params<crate::schemas::network_capnp::authenticated_server_connection::send_throw_action_params::Owned>;
-  pub type SendThrowActionResults<> = ::capnp::capability::Results<crate::schemas::network_capnp::authenticated_server_connection::send_throw_action_results::Owned>;
+  pub type SendBlockActionParams<> = ::capnp::capability::Params<crate::schemas::network_capnp::authenticated_server_connection::send_block_action_params::Owned>;
+  pub type SendBlockActionResults<> = ::capnp::capability::Results<crate::schemas::network_capnp::authenticated_server_connection::send_block_action_results::Owned>;
 
   pub struct Client {
     pub client: ::capnp::capability::Client,
@@ -3658,14 +3658,14 @@ pub mod authenticated_server_connection {
     pub fn send_chat_message_request(&self) -> ::capnp::capability::Request<crate::schemas::network_capnp::authenticated_server_connection::send_chat_message_params::Owned,crate::schemas::network_capnp::authenticated_server_connection::send_chat_message_results::Owned> {
       self.client.new_call(_private::TYPE_ID, 1, ::core::option::Option::None)
     }
-    pub fn send_throw_action_request(&self) -> ::capnp::capability::Request<crate::schemas::network_capnp::authenticated_server_connection::send_throw_action_params::Owned,crate::schemas::network_capnp::authenticated_server_connection::send_throw_action_results::Owned> {
+    pub fn send_block_action_request(&self) -> ::capnp::capability::Request<crate::schemas::network_capnp::authenticated_server_connection::send_block_action_params::Owned,crate::schemas::network_capnp::authenticated_server_connection::send_block_action_results::Owned> {
       self.client.new_call(_private::TYPE_ID, 2, ::core::option::Option::None)
     }
   }
   pub trait Server<>   {
     fn bootstrap_game_data(&mut self, _: BootstrapGameDataParams<>, _: BootstrapGameDataResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method authenticated_server_connection::Server::bootstrap_game_data not implemented".to_string())) }
     fn send_chat_message(&mut self, _: SendChatMessageParams<>, _: SendChatMessageResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method authenticated_server_connection::Server::send_chat_message not implemented".to_string())) }
-    fn send_throw_action(&mut self, _: SendThrowActionParams<>, _: SendThrowActionResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method authenticated_server_connection::Server::send_throw_action not implemented".to_string())) }
+    fn send_block_action(&mut self, _: SendBlockActionParams<>, _: SendBlockActionResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method authenticated_server_connection::Server::send_block_action not implemented".to_string())) }
   }
   pub struct ServerDispatch<_T,> {
     pub server: _T,
@@ -3696,7 +3696,7 @@ pub mod authenticated_server_connection {
       match method_id {
         0 => ::capnp::capability::DispatchCallResult::new(server.bootstrap_game_data(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)), false),
         1 => ::capnp::capability::DispatchCallResult::new(server.send_chat_message(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)), false),
-        2 => ::capnp::capability::DispatchCallResult::new(server.send_throw_action(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)), false),
+        2 => ::capnp::capability::DispatchCallResult::new(server.send_block_action(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)), false),
         _ => { ::capnp::capability::DispatchCallResult::new(::capnp::capability::Promise::err(::capnp::Error::unimplemented("Method not implemented.".to_string())), false) }
       }
     }
@@ -4470,7 +4470,7 @@ pub mod authenticated_server_connection {
     }
   }
 
-  pub mod send_throw_action_params {
+  pub mod send_block_action_params {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
@@ -4544,11 +4544,11 @@ pub mod authenticated_server_connection {
         !self.reader.get_pointer_field(0).is_null()
       }
       #[inline]
-      pub fn get_throw(self) -> ::capnp::Result<crate::schemas::game_types_capnp::throw_action::Reader<'a>> {
+      pub fn get_action(self) -> ::capnp::Result<crate::schemas::game_types_capnp::block_action::Reader<'a>> {
         ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
       }
       #[inline]
-      pub fn has_throw(&self) -> bool {
+      pub fn has_action(&self) -> bool {
         !self.reader.get_pointer_field(1).is_null()
       }
     }
@@ -4630,19 +4630,19 @@ pub mod authenticated_server_connection {
         !self.builder.is_pointer_field_null(0)
       }
       #[inline]
-      pub fn get_throw(self) -> ::capnp::Result<crate::schemas::game_types_capnp::throw_action::Builder<'a>> {
+      pub fn get_action(self) -> ::capnp::Result<crate::schemas::game_types_capnp::block_action::Builder<'a>> {
         ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
       }
       #[inline]
-      pub fn set_throw(&mut self, value: crate::schemas::game_types_capnp::throw_action::Reader<'_>) -> ::capnp::Result<()> {
+      pub fn set_action(&mut self, value: crate::schemas::game_types_capnp::block_action::Reader<'_>) -> ::capnp::Result<()> {
         ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(1), value, false)
       }
       #[inline]
-      pub fn init_throw(self, ) -> crate::schemas::game_types_capnp::throw_action::Builder<'a> {
+      pub fn init_action(self, ) -> crate::schemas::game_types_capnp::block_action::Builder<'a> {
         ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
       }
       #[inline]
-      pub fn has_throw(&self) -> bool {
+      pub fn has_action(&self) -> bool {
         !self.builder.is_pointer_field_null(1)
       }
     }
@@ -4657,7 +4657,7 @@ pub mod authenticated_server_connection {
       pub fn get_position(&self) -> crate::schemas::game_types_capnp::position_data::Pipeline {
         ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
       }
-      pub fn get_throw(&self) -> crate::schemas::game_types_capnp::throw_action::Pipeline {
+      pub fn get_action(&self) -> crate::schemas::game_types_capnp::block_action::Pipeline {
         ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
       }
     }
@@ -4682,7 +4682,7 @@ pub mod authenticated_server_connection {
         ::capnp::word(116, 101, 100, 83, 101, 114, 118, 101),
         ::capnp::word(114, 67, 111, 110, 110, 101, 99, 116),
         ::capnp::word(105, 111, 110, 46, 115, 101, 110, 100),
-        ::capnp::word(84, 104, 114, 111, 119, 65, 99, 116),
+        ::capnp::word(66, 108, 111, 99, 107, 65, 99, 116),
         ::capnp::word(105, 111, 110, 36, 80, 97, 114, 97),
         ::capnp::word(109, 115, 0, 0, 0, 0, 0, 0),
         ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
@@ -4703,7 +4703,7 @@ pub mod authenticated_server_connection {
         ::capnp::word(2, 0, 0, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(81, 0, 0, 0, 50, 0, 0, 0),
+        ::capnp::word(81, 0, 0, 0, 58, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(76, 0, 0, 0, 3, 0, 1, 0),
         ::capnp::word(88, 0, 0, 0, 2, 0, 1, 0),
@@ -4724,9 +4724,9 @@ pub mod authenticated_server_connection {
         ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(116, 104, 114, 111, 119, 0, 0, 0),
+        ::capnp::word(97, 99, 116, 105, 111, 110, 0, 0),
         ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(155, 58, 165, 109, 213, 129, 125, 200),
+        ::capnp::word(114, 249, 128, 56, 240, 42, 102, 129),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
@@ -4737,7 +4737,7 @@ pub mod authenticated_server_connection {
         match index {
           0 => <u64 as ::capnp::introspect::Introspect>::introspect(),
           1 => <crate::schemas::game_types_capnp::position_data::Owned as ::capnp::introspect::Introspect>::introspect(),
-          2 => <crate::schemas::game_types_capnp::throw_action::Owned as ::capnp::introspect::Introspect>::introspect(),
+          2 => <crate::schemas::game_types_capnp::block_action::Owned as ::capnp::introspect::Introspect>::introspect(),
           _ => panic!("invalid field index {}", index),
         }
       }
@@ -4752,12 +4752,12 @@ pub mod authenticated_server_connection {
       };
       pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
       pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub static MEMBERS_BY_NAME : &[u16] = &[1,2,0];
+      pub static MEMBERS_BY_NAME : &[u16] = &[2,1,0];
       pub const TYPE_ID: u64 = 0xe03c_e773_e562_e57f;
     }
   }
 
-  pub mod send_throw_action_results {
+  pub mod send_block_action_results {
     #[derive(Copy, Clone)]
     pub struct Owned(());
     impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
@@ -4903,7 +4903,7 @@ pub mod authenticated_server_connection {
         ::capnp::word(116, 101, 100, 83, 101, 114, 118, 101),
         ::capnp::word(114, 67, 111, 110, 110, 101, 99, 116),
         ::capnp::word(105, 111, 110, 46, 115, 101, 110, 100),
-        ::capnp::word(84, 104, 114, 111, 119, 65, 99, 116),
+        ::capnp::word(66, 108, 111, 99, 107, 65, 99, 116),
         ::capnp::word(105, 111, 110, 36, 82, 101, 115, 117),
         ::capnp::word(108, 116, 115, 0, 0, 0, 0, 0),
       ];
@@ -5138,7 +5138,7 @@ pub mod chunk_data_stream_packet {
       ::capnp::word(203, 38, 210, 159, 176, 70, 145, 184),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(102, 11, 0, 0, 178, 12, 0, 0),
+      ::capnp::word(103, 11, 0, 0, 179, 12, 0, 0),
       ::capnp::word(21, 0, 0, 0, 34, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),

--- a/lib/gs_schemas/capnp-generated/network_capnp.rs
+++ b/lib/gs_schemas/capnp-generated/network_capnp.rs
@@ -4532,6 +4532,10 @@ pub mod authenticated_server_connection {
         self.reader.total_size()
       }
       #[inline]
+      pub fn get_tick(self) -> u64 {
+        self.reader.get_data_field::<u64>(0)
+      }
+      #[inline]
       pub fn get_position(self) -> ::capnp::Result<crate::schemas::game_types_capnp::position_data::Reader<'a>> {
         ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
       }
@@ -4551,7 +4555,7 @@ pub mod authenticated_server_connection {
 
     pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
     impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
-      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 2 };
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 1, pointers: 2 };
     }
     impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
       const TYPE_ID: u64 = _private::TYPE_ID;
@@ -4602,6 +4606,14 @@ pub mod authenticated_server_connection {
         self.builder.as_reader().total_size()
       }
       #[inline]
+      pub fn get_tick(self) -> u64 {
+        self.builder.get_data_field::<u64>(0)
+      }
+      #[inline]
+      pub fn set_tick(&mut self, value: u64)  {
+        self.builder.set_data_field::<u64>(0, value);
+      }
+      #[inline]
       pub fn get_position(self) -> ::capnp::Result<crate::schemas::game_types_capnp::position_data::Builder<'a>> {
         ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
       }
@@ -4650,10 +4662,10 @@ pub mod authenticated_server_connection {
       }
     }
     mod _private {
-      pub static ENCODED_NODE: [::capnp::Word; 54] = [
+      pub static ENCODED_NODE: [::capnp::Word; 69] = [
         ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
         ::capnp::word(127, 229, 98, 229, 115, 231, 60, 224),
-        ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
+        ::capnp::word(44, 0, 0, 0, 1, 0, 1, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
@@ -4661,7 +4673,7 @@ pub mod authenticated_server_connection {
         ::capnp::word(21, 0, 0, 0, 26, 2, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(45, 0, 0, 0, 119, 0, 0, 0),
+        ::capnp::word(45, 0, 0, 0, 175, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(110, 101, 116, 119, 111, 114, 107, 46),
@@ -4673,21 +4685,36 @@ pub mod authenticated_server_connection {
         ::capnp::word(84, 104, 114, 111, 119, 65, 99, 116),
         ::capnp::word(105, 111, 110, 36, 80, 97, 114, 97),
         ::capnp::word(109, 115, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
+        ::capnp::word(12, 0, 0, 0, 3, 0, 4, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(41, 0, 0, 0, 74, 0, 0, 0),
+        ::capnp::word(69, 0, 0, 0, 42, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(52, 0, 0, 0, 2, 0, 1, 0),
-        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+        ::capnp::word(64, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(76, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(1, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(49, 0, 0, 0, 50, 0, 0, 0),
+        ::capnp::word(73, 0, 0, 0, 74, 0, 0, 0),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-        ::capnp::word(44, 0, 0, 0, 3, 0, 1, 0),
-        ::capnp::word(56, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(72, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(84, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(2, 0, 0, 0, 1, 0, 0, 0),
+        ::capnp::word(0, 0, 1, 0, 2, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(81, 0, 0, 0, 50, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(76, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(88, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(116, 105, 99, 107, 0, 0, 0, 0),
+        ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(9, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(112, 111, 115, 105, 116, 105, 111, 110),
         ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
         ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
@@ -4708,8 +4735,9 @@ pub mod authenticated_server_connection {
       ];
       pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
         match index {
-          0 => <crate::schemas::game_types_capnp::position_data::Owned as ::capnp::introspect::Introspect>::introspect(),
-          1 => <crate::schemas::game_types_capnp::throw_action::Owned as ::capnp::introspect::Introspect>::introspect(),
+          0 => <u64 as ::capnp::introspect::Introspect>::introspect(),
+          1 => <crate::schemas::game_types_capnp::position_data::Owned as ::capnp::introspect::Introspect>::introspect(),
+          2 => <crate::schemas::game_types_capnp::throw_action::Owned as ::capnp::introspect::Introspect>::introspect(),
           _ => panic!("invalid field index {}", index),
         }
       }
@@ -4722,9 +4750,9 @@ pub mod authenticated_server_connection {
         members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
         members_by_name: MEMBERS_BY_NAME,
       };
-      pub static NONUNION_MEMBERS : &[u16] = &[0,1];
+      pub static NONUNION_MEMBERS : &[u16] = &[0,1,2];
       pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
-      pub static MEMBERS_BY_NAME : &[u16] = &[0,1];
+      pub static MEMBERS_BY_NAME : &[u16] = &[1,2,0];
       pub const TYPE_ID: u64 = 0xe03c_e773_e562_e57f;
     }
   }
@@ -5110,7 +5138,7 @@ pub mod chunk_data_stream_packet {
       ::capnp::word(203, 38, 210, 159, 176, 70, 145, 184),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(88, 11, 0, 0, 164, 12, 0, 0),
+      ::capnp::word(102, 11, 0, 0, 178, 12, 0, 0),
       ::capnp::word(21, 0, 0, 0, 34, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),

--- a/lib/gs_schemas/capnp-generated/network_capnp.rs
+++ b/lib/gs_schemas/capnp-generated/network_capnp.rs
@@ -3601,6 +3601,8 @@ pub mod authenticated_server_connection {
   pub type BootstrapGameDataResults<> = ::capnp::capability::Results<crate::schemas::network_capnp::authenticated_server_connection::bootstrap_game_data_results::Owned>;
   pub type SendChatMessageParams<> = ::capnp::capability::Params<crate::schemas::network_capnp::authenticated_server_connection::send_chat_message_params::Owned>;
   pub type SendChatMessageResults<> = ::capnp::capability::Results<crate::schemas::network_capnp::authenticated_server_connection::send_chat_message_results::Owned>;
+  pub type SendThrowActionParams<> = ::capnp::capability::Params<crate::schemas::network_capnp::authenticated_server_connection::send_throw_action_params::Owned>;
+  pub type SendThrowActionResults<> = ::capnp::capability::Results<crate::schemas::network_capnp::authenticated_server_connection::send_throw_action_results::Owned>;
 
   pub struct Client {
     pub client: ::capnp::capability::Client,
@@ -3656,10 +3658,14 @@ pub mod authenticated_server_connection {
     pub fn send_chat_message_request(&self) -> ::capnp::capability::Request<crate::schemas::network_capnp::authenticated_server_connection::send_chat_message_params::Owned,crate::schemas::network_capnp::authenticated_server_connection::send_chat_message_results::Owned> {
       self.client.new_call(_private::TYPE_ID, 1, ::core::option::Option::None)
     }
+    pub fn send_throw_action_request(&self) -> ::capnp::capability::Request<crate::schemas::network_capnp::authenticated_server_connection::send_throw_action_params::Owned,crate::schemas::network_capnp::authenticated_server_connection::send_throw_action_results::Owned> {
+      self.client.new_call(_private::TYPE_ID, 2, ::core::option::Option::None)
+    }
   }
   pub trait Server<>   {
     fn bootstrap_game_data(&mut self, _: BootstrapGameDataParams<>, _: BootstrapGameDataResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method authenticated_server_connection::Server::bootstrap_game_data not implemented".to_string())) }
     fn send_chat_message(&mut self, _: SendChatMessageParams<>, _: SendChatMessageResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method authenticated_server_connection::Server::send_chat_message not implemented".to_string())) }
+    fn send_throw_action(&mut self, _: SendThrowActionParams<>, _: SendThrowActionResults<>) -> ::capnp::capability::Promise<(), ::capnp::Error> { ::capnp::capability::Promise::err(::capnp::Error::unimplemented("method authenticated_server_connection::Server::send_throw_action not implemented".to_string())) }
   }
   pub struct ServerDispatch<_T,> {
     pub server: _T,
@@ -3690,6 +3696,7 @@ pub mod authenticated_server_connection {
       match method_id {
         0 => ::capnp::capability::DispatchCallResult::new(server.bootstrap_game_data(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)), false),
         1 => ::capnp::capability::DispatchCallResult::new(server.send_chat_message(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)), false),
+        2 => ::capnp::capability::DispatchCallResult::new(server.send_throw_action(::capnp::private::capability::internal_get_typed_params(params), ::capnp::private::capability::internal_get_typed_results(results)), false),
         _ => { ::capnp::capability::DispatchCallResult::new(::capnp::capability::Promise::err(::capnp::Error::unimplemented("Method not implemented.".to_string())), false) }
       }
     }
@@ -4462,6 +4469,434 @@ pub mod authenticated_server_connection {
       pub const TYPE_ID: u64 = 0x8206_b95d_02cb_e2f7;
     }
   }
+
+  pub mod send_throw_action_params {
+    #[derive(Copy, Clone)]
+    pub struct Owned(());
+    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
+    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    impl <> ::core::marker::Copy for Reader<'_,>  {}
+    impl <> ::core::clone::Clone for Reader<'_,>  {
+      fn clone(&self) -> Self { *self }
+    }
+
+    impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
+      const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
+      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+        Self { reader,  }
+      }
+    }
+
+    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
+      fn from(reader: Reader<'a,>) -> Self {
+        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+      }
+    }
+
+    impl <> ::core::fmt::Debug for Reader<'_,>  {
+      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
+        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+        ::core::result::Result::Ok(reader.get_struct(default)?.into())
+      }
+    }
+
+    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+        self.reader
+      }
+    }
+
+    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+      }
+    }
+
+    impl <'a,> Reader<'a,>  {
+      pub fn reborrow(&self) -> Reader<'_,> {
+        Self { .. *self }
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.reader.total_size()
+      }
+      #[inline]
+      pub fn get_position(self) -> ::capnp::Result<crate::schemas::game_types_capnp::position_data::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(0), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn has_position(&self) -> bool {
+        !self.reader.get_pointer_field(0).is_null()
+      }
+      #[inline]
+      pub fn get_throw(self) -> ::capnp::Result<crate::schemas::game_types_capnp::throw_action::Reader<'a>> {
+        ::capnp::traits::FromPointerReader::get_from_pointer(&self.reader.get_pointer_field(1), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn has_throw(&self) -> bool {
+        !self.reader.get_pointer_field(1).is_null()
+      }
+    }
+
+    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+    impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 2 };
+    }
+    impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
+      const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
+      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+        Self { builder,  }
+      }
+    }
+
+    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
+      fn from(builder: Builder<'a,>) -> Self {
+        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
+      }
+      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
+      }
+    }
+
+    impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    }
+
+    impl <'a,> Builder<'a,>  {
+      pub fn into_reader(self) -> Reader<'a,> {
+        self.builder.into_reader().into()
+      }
+      pub fn reborrow(&mut self) -> Builder<'_,> {
+        Builder { builder: self.builder.reborrow() }
+      }
+      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+        self.builder.as_reader().into()
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.builder.as_reader().total_size()
+      }
+      #[inline]
+      pub fn get_position(self) -> ::capnp::Result<crate::schemas::game_types_capnp::position_data::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(0), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_position(&mut self, value: crate::schemas::game_types_capnp::position_data::Reader<'_>) -> ::capnp::Result<()> {
+        ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(0), value, false)
+      }
+      #[inline]
+      pub fn init_position(self, ) -> crate::schemas::game_types_capnp::position_data::Builder<'a> {
+        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(0), 0)
+      }
+      #[inline]
+      pub fn has_position(&self) -> bool {
+        !self.builder.is_pointer_field_null(0)
+      }
+      #[inline]
+      pub fn get_throw(self) -> ::capnp::Result<crate::schemas::game_types_capnp::throw_action::Builder<'a>> {
+        ::capnp::traits::FromPointerBuilder::get_from_pointer(self.builder.get_pointer_field(1), ::core::option::Option::None)
+      }
+      #[inline]
+      pub fn set_throw(&mut self, value: crate::schemas::game_types_capnp::throw_action::Reader<'_>) -> ::capnp::Result<()> {
+        ::capnp::traits::SetterInput::set_pointer_builder(self.builder.reborrow().get_pointer_field(1), value, false)
+      }
+      #[inline]
+      pub fn init_throw(self, ) -> crate::schemas::game_types_capnp::throw_action::Builder<'a> {
+        ::capnp::traits::FromPointerBuilder::init_pointer(self.builder.get_pointer_field(1), 0)
+      }
+      #[inline]
+      pub fn has_throw(&self) -> bool {
+        !self.builder.is_pointer_field_null(1)
+      }
+    }
+
+    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+        Self { _typeless: typeless,  }
+      }
+    }
+    impl Pipeline  {
+      pub fn get_position(&self) -> crate::schemas::game_types_capnp::position_data::Pipeline {
+        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(0))
+      }
+      pub fn get_throw(&self) -> crate::schemas::game_types_capnp::throw_action::Pipeline {
+        ::capnp::capability::FromTypelessPipeline::new(self._typeless.get_pointer_field(1))
+      }
+    }
+    mod _private {
+      pub static ENCODED_NODE: [::capnp::Word; 54] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
+        ::capnp::word(127, 229, 98, 229, 115, 231, 60, 224),
+        ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(21, 0, 0, 0, 26, 2, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(45, 0, 0, 0, 119, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(110, 101, 116, 119, 111, 114, 107, 46),
+        ::capnp::word(99, 97, 112, 110, 112, 58, 65, 117),
+        ::capnp::word(116, 104, 101, 110, 116, 105, 99, 97),
+        ::capnp::word(116, 101, 100, 83, 101, 114, 118, 101),
+        ::capnp::word(114, 67, 111, 110, 110, 101, 99, 116),
+        ::capnp::word(105, 111, 110, 46, 115, 101, 110, 100),
+        ::capnp::word(84, 104, 114, 111, 119, 65, 99, 116),
+        ::capnp::word(105, 111, 110, 36, 80, 97, 114, 97),
+        ::capnp::word(109, 115, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(8, 0, 0, 0, 3, 0, 4, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 1, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(41, 0, 0, 0, 74, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(40, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(52, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(1, 0, 0, 0, 1, 0, 0, 0),
+        ::capnp::word(0, 0, 1, 0, 1, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(49, 0, 0, 0, 50, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(44, 0, 0, 0, 3, 0, 1, 0),
+        ::capnp::word(56, 0, 0, 0, 2, 0, 1, 0),
+        ::capnp::word(112, 111, 115, 105, 116, 105, 111, 110),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(224, 249, 178, 196, 42, 142, 176, 165),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(116, 104, 114, 111, 119, 0, 0, 0),
+        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(155, 58, 165, 109, 213, 129, 125, 200),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(16, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+      ];
+      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+        match index {
+          0 => <crate::schemas::game_types_capnp::position_data::Owned as ::capnp::introspect::Introspect>::introspect(),
+          1 => <crate::schemas::game_types_capnp::throw_action::Owned as ::capnp::introspect::Introspect>::introspect(),
+          _ => panic!("invalid field index {}", index),
+        }
+      }
+      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
+        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+      }
+      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
+        encoded_node: &ENCODED_NODE,
+        nonunion_members: NONUNION_MEMBERS,
+        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+        members_by_name: MEMBERS_BY_NAME,
+      };
+      pub static NONUNION_MEMBERS : &[u16] = &[0,1];
+      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
+      pub static MEMBERS_BY_NAME : &[u16] = &[0,1];
+      pub const TYPE_ID: u64 = 0xe03c_e773_e562_e57f;
+    }
+  }
+
+  pub mod send_throw_action_results {
+    #[derive(Copy, Clone)]
+    pub struct Owned(());
+    impl ::capnp::introspect::Introspect for Owned { fn introspect() -> ::capnp::introspect::Type { ::capnp::introspect::TypeVariant::Struct(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types, annotation_types: _private::get_annotation_types }).into() } }
+    impl ::capnp::traits::Owned for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl ::capnp::traits::OwnedStruct for Owned { type Reader<'a> = Reader<'a>; type Builder<'a> = Builder<'a>; }
+    impl ::capnp::traits::Pipelined for Owned { type Pipeline = Pipeline; }
+
+    pub struct Reader<'a> { reader: ::capnp::private::layout::StructReader<'a> }
+    impl <> ::core::marker::Copy for Reader<'_,>  {}
+    impl <> ::core::clone::Clone for Reader<'_,>  {
+      fn clone(&self) -> Self { *self }
+    }
+
+    impl <> ::capnp::traits::HasTypeId for Reader<'_,>  {
+      const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl <'a,> ::core::convert::From<::capnp::private::layout::StructReader<'a>> for Reader<'a,>  {
+      fn from(reader: ::capnp::private::layout::StructReader<'a>) -> Self {
+        Self { reader,  }
+      }
+    }
+
+    impl <'a,> ::core::convert::From<Reader<'a,>> for ::capnp::dynamic_value::Reader<'a>  {
+      fn from(reader: Reader<'a,>) -> Self {
+        Self::Struct(::capnp::dynamic_struct::Reader::new(reader.reader, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+      }
+    }
+
+    impl <> ::core::fmt::Debug for Reader<'_,>  {
+      fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::result::Result<(), ::core::fmt::Error> {
+        core::fmt::Debug::fmt(&::core::convert::Into::<::capnp::dynamic_value::Reader<'_>>::into(*self), f)
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerReader<'a> for Reader<'a,>  {
+      fn get_from_pointer(reader: &::capnp::private::layout::PointerReader<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+        ::core::result::Result::Ok(reader.get_struct(default)?.into())
+      }
+    }
+
+    impl <'a,> ::capnp::traits::IntoInternalStructReader<'a> for Reader<'a,>  {
+      fn into_internal_struct_reader(self) -> ::capnp::private::layout::StructReader<'a> {
+        self.reader
+      }
+    }
+
+    impl <'a,> ::capnp::traits::Imbue<'a> for Reader<'a,>  {
+      fn imbue(&mut self, cap_table: &'a ::capnp::private::layout::CapTable) {
+        self.reader.imbue(::capnp::private::layout::CapTableReader::Plain(cap_table))
+      }
+    }
+
+    impl <> Reader<'_,>  {
+      pub fn reborrow(&self) -> Reader<'_,> {
+        Self { .. *self }
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.reader.total_size()
+      }
+    }
+
+    pub struct Builder<'a> { builder: ::capnp::private::layout::StructBuilder<'a> }
+    impl <> ::capnp::traits::HasStructSize for Builder<'_,>  {
+      const STRUCT_SIZE: ::capnp::private::layout::StructSize = ::capnp::private::layout::StructSize { data: 0, pointers: 0 };
+    }
+    impl <> ::capnp::traits::HasTypeId for Builder<'_,>  {
+      const TYPE_ID: u64 = _private::TYPE_ID;
+    }
+    impl <'a,> ::core::convert::From<::capnp::private::layout::StructBuilder<'a>> for Builder<'a,>  {
+      fn from(builder: ::capnp::private::layout::StructBuilder<'a>) -> Self {
+        Self { builder,  }
+      }
+    }
+
+    impl <'a,> ::core::convert::From<Builder<'a,>> for ::capnp::dynamic_value::Builder<'a>  {
+      fn from(builder: Builder<'a,>) -> Self {
+        Self::Struct(::capnp::dynamic_struct::Builder::new(builder.builder, ::capnp::schema::StructSchema::new(::capnp::introspect::RawBrandedStructSchema { generic: &_private::RAW_SCHEMA, field_types: _private::get_field_types::<>, annotation_types: _private::get_annotation_types::<>})))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::ImbueMut<'a> for Builder<'a,>  {
+      fn imbue_mut(&mut self, cap_table: &'a mut ::capnp::private::layout::CapTable) {
+        self.builder.imbue(::capnp::private::layout::CapTableBuilder::Plain(cap_table))
+      }
+    }
+
+    impl <'a,> ::capnp::traits::FromPointerBuilder<'a> for Builder<'a,>  {
+      fn init_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, _size: u32) -> Self {
+        builder.init_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE).into()
+      }
+      fn get_from_pointer(builder: ::capnp::private::layout::PointerBuilder<'a>, default: ::core::option::Option<&'a [::capnp::Word]>) -> ::capnp::Result<Self> {
+        ::core::result::Result::Ok(builder.get_struct(<Self as ::capnp::traits::HasStructSize>::STRUCT_SIZE, default)?.into())
+      }
+    }
+
+    impl <> ::capnp::traits::SetterInput<Owned<>> for Reader<'_,>  {
+      fn set_pointer_builder(mut pointer: ::capnp::private::layout::PointerBuilder<'_>, value: Self, canonicalize: bool) -> ::capnp::Result<()> { pointer.set_struct(&value.reader, canonicalize) }
+    }
+
+    impl <'a,> Builder<'a,>  {
+      pub fn into_reader(self) -> Reader<'a,> {
+        self.builder.into_reader().into()
+      }
+      pub fn reborrow(&mut self) -> Builder<'_,> {
+        Builder { builder: self.builder.reborrow() }
+      }
+      pub fn reborrow_as_reader(&self) -> Reader<'_,> {
+        self.builder.as_reader().into()
+      }
+
+      pub fn total_size(&self) -> ::capnp::Result<::capnp::MessageSize> {
+        self.builder.as_reader().total_size()
+      }
+    }
+
+    pub struct Pipeline { _typeless: ::capnp::any_pointer::Pipeline }
+    impl ::capnp::capability::FromTypelessPipeline for Pipeline {
+      fn new(typeless: ::capnp::any_pointer::Pipeline) -> Self {
+        Self { _typeless: typeless,  }
+      }
+    }
+    impl Pipeline  {
+    }
+    mod _private {
+      pub static ENCODED_NODE: [::capnp::Word; 22] = [
+        ::capnp::word(0, 0, 0, 0, 6, 0, 6, 0),
+        ::capnp::word(76, 94, 248, 114, 160, 147, 215, 211),
+        ::capnp::word(44, 0, 0, 0, 1, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 7, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(21, 0, 0, 0, 34, 2, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
+        ::capnp::word(110, 101, 116, 119, 111, 114, 107, 46),
+        ::capnp::word(99, 97, 112, 110, 112, 58, 65, 117),
+        ::capnp::word(116, 104, 101, 110, 116, 105, 99, 97),
+        ::capnp::word(116, 101, 100, 83, 101, 114, 118, 101),
+        ::capnp::word(114, 67, 111, 110, 110, 101, 99, 116),
+        ::capnp::word(105, 111, 110, 46, 115, 101, 110, 100),
+        ::capnp::word(84, 104, 114, 111, 119, 65, 99, 116),
+        ::capnp::word(105, 111, 110, 36, 82, 101, 115, 117),
+        ::capnp::word(108, 116, 115, 0, 0, 0, 0, 0),
+      ];
+      pub fn get_field_types(index: u16) -> ::capnp::introspect::Type {
+        panic!("invalid field index {}", index)
+      }
+      pub fn get_annotation_types(child_index: Option<u16>, index: u32) -> ::capnp::introspect::Type {
+        panic!("invalid annotation indices ({:?}, {}) ", child_index, index)
+      }
+      pub static RAW_SCHEMA: ::capnp::introspect::RawStructSchema = ::capnp::introspect::RawStructSchema {
+        encoded_node: &ENCODED_NODE,
+        nonunion_members: NONUNION_MEMBERS,
+        members_by_discriminant: MEMBERS_BY_DISCRIMINANT,
+        members_by_name: MEMBERS_BY_NAME,
+      };
+      pub static NONUNION_MEMBERS : &[u16] = &[];
+      pub static MEMBERS_BY_DISCRIMINANT : &[u16] = &[];
+      pub static MEMBERS_BY_NAME : &[u16] = &[];
+      pub const TYPE_ID: u64 = 0xd3d7_93a0_72f8_5e4c;
+    }
+  }
 }
 
 pub mod chunk_data_stream_packet {
@@ -4675,7 +5110,7 @@ pub mod chunk_data_stream_packet {
       ::capnp::word(203, 38, 210, 159, 176, 70, 145, 184),
       ::capnp::word(2, 0, 7, 0, 0, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),
-      ::capnp::word(207, 10, 0, 0, 27, 12, 0, 0),
+      ::capnp::word(88, 11, 0, 0, 164, 12, 0, 0),
       ::capnp::word(21, 0, 0, 0, 34, 1, 0, 0),
       ::capnp::word(37, 0, 0, 0, 7, 0, 0, 0),
       ::capnp::word(0, 0, 0, 0, 0, 0, 0, 0),

--- a/lib/gs_schemas/capnp/game_types.capnp
+++ b/lib/gs_schemas/capnp/game_types.capnp
@@ -102,3 +102,21 @@ struct FullChunkData {
     blockPalette @0 :List(UInt64);
     blockData @1 :List(UInt16);
 }
+
+# Action Data
+struct PositionData {
+    position @0 :IVec3;
+    offset @1 :Vec3;
+    look @2 :Vec3;
+}
+
+struct ThrowAction {
+    union {
+        throwBlock :group {
+            unused @0 :Void;
+        }
+        throwItem :group {
+            unused @1 :Void;
+        }
+    }
+}

--- a/lib/gs_schemas/capnp/game_types.capnp
+++ b/lib/gs_schemas/capnp/game_types.capnp
@@ -110,12 +110,14 @@ struct PositionData {
     look @2 :Vec3;
 }
 
-struct ThrowAction {
+struct BlockAction {
     union {
-        throwBlock :group {
+        placeBlock :group {
+            # should eventually contain information on what is being placed
             unused @0 :Void;
         }
-        throwItem :group {
+        breakBlock :group {
+            # not used
             unused @1 :Void;
         }
     }

--- a/lib/gs_schemas/capnp/network.capnp
+++ b/lib/gs_schemas/capnp/network.capnp
@@ -76,6 +76,8 @@ interface AuthenticatedServerConnection @0xcc65c2f3643e6ae0 {
     bootstrapGameData @0 () -> (data: GameTypes.GameBootstrapData);
     # Sends a chat message to the server.
     sendChatMessage @1 (text: Text) -> ();
+    # Sends a throw action to the server.
+    sendThrowAction @2 (position: GameTypes.PositionData, throw: GameTypes.ThrowAction) -> ();
 }
 
 struct ChunkDataStreamPacket {

--- a/lib/gs_schemas/capnp/network.capnp
+++ b/lib/gs_schemas/capnp/network.capnp
@@ -76,8 +76,8 @@ interface AuthenticatedServerConnection @0xcc65c2f3643e6ae0 {
     bootstrapGameData @0 () -> (data: GameTypes.GameBootstrapData);
     # Sends a chat message to the server.
     sendChatMessage @1 (text: Text) -> ();
-    # Sends a throw action to the server.
-    sendThrowAction @2 (tick: UInt64, position: GameTypes.PositionData, throw: GameTypes.ThrowAction) -> ();
+    # Sends a block action to the server.
+    sendBlockAction @2 (tick: UInt64, position: GameTypes.PositionData, action: GameTypes.BlockAction) -> ();
 }
 
 struct ChunkDataStreamPacket {

--- a/lib/gs_schemas/capnp/network.capnp
+++ b/lib/gs_schemas/capnp/network.capnp
@@ -77,7 +77,7 @@ interface AuthenticatedServerConnection @0xcc65c2f3643e6ae0 {
     # Sends a chat message to the server.
     sendChatMessage @1 (text: Text) -> ();
     # Sends a throw action to the server.
-    sendThrowAction @2 (position: GameTypes.PositionData, throw: GameTypes.ThrowAction) -> ();
+    sendThrowAction @2 (tick: UInt64, position: GameTypes.PositionData, throw: GameTypes.ThrowAction) -> ();
 }
 
 struct ChunkDataStreamPacket {

--- a/lib/gs_schemas/src/actions.rs
+++ b/lib/gs_schemas/src/actions.rs
@@ -1,0 +1,112 @@
+//! Actions that are generally triggered by clients and handled on the server.
+
+use bevy_math::{IVec3, Vec3};
+use crate::actions::ThrowAction::{ThrowBlock, ThrowItem};
+use crate::coordinates::AbsBlockPos;
+use crate::schemas::game_types_capnp::{position_data, throw_action};
+
+/// Position data
+#[derive(Debug, Copy, Clone)]
+pub struct PositionData {
+    /// Position in the world
+    pub position: AbsBlockPos,
+    /// offset from position
+    pub offset: Vec3,
+    /// look vector
+    pub look: Vec3,
+}
+
+impl TryFrom<position_data::Reader<'_>> for PositionData {
+    type Error = ();
+
+    fn try_from(value: position_data::Reader) -> Result<Self, Self::Error> {
+        let position = {
+            let pos = value.reborrow().get_position().map_err(|_| {()})?;
+            AbsBlockPos { 0: IVec3 {
+                x: pos.get_x(),
+                y: pos.get_y(),
+                z: pos.get_z()
+            }}
+        };
+        let offset = {
+            let offset = value.reborrow().get_offset().map_err(|_| {()})?;
+            Vec3 {
+                x: offset.get_x(),
+                y: offset.get_y(),
+                z: offset.get_z(),
+            }
+        };
+        let look = {
+            let look = value.reborrow().get_look().map_err(|_| {()})?;
+            Vec3 {
+                x: look.get_x(),
+                y: look.get_y(),
+                z: look.get_z(),
+            }
+        };
+        Ok(PositionData { position, offset, look })
+    }
+}
+
+impl PositionData {
+
+    /// writes this position data to the given builder
+    pub fn to_builder(self, builder: &mut position_data::Builder<'_>) {
+        {
+            let mut pos = builder.reborrow().init_position();
+            pos.set_x(self.position.x);
+            pos.set_y(self.position.y);
+            pos.set_z(self.position.z);
+        }
+        {
+            let mut offset = builder.reborrow().init_offset();
+            offset.set_x(self.offset.x);
+            offset.set_y(self.offset.y);
+            offset.set_z(self.offset.z);
+        }
+        {
+            let mut look = builder.reborrow().init_look();
+            look.set_x(self.look.x);
+            look.set_y(self.look.y);
+            look.set_z(self.look.z);
+        }
+    }
+}
+
+/// Throw Action, for world interaction
+#[derive(Debug, Copy, Clone)]
+pub enum ThrowAction {
+    ThrowBlock(),
+    ThrowItem(),
+}
+
+impl TryFrom<throw_action::Reader<'_>> for ThrowAction {
+    type Error = ();
+
+    fn try_from(value: throw_action::Reader) -> Result<Self, Self::Error> {
+        match value.reborrow().which() {
+            Ok(throw_action::Which::ThrowItem(_)) => {
+                Ok(ThrowItem())
+            }
+            Ok(throw_action::Which::ThrowBlock(_)) => {
+                Ok(ThrowBlock())
+            }
+            _ => Err(())
+        }
+    }
+}
+
+impl ThrowAction {
+
+    /// writes this throw action to the given builder
+    pub fn to_builder(self, builder: &mut throw_action::Builder<'_>) {
+        match self {
+            ThrowBlock() => {
+                builder.reborrow().init_throw_block().set_unused(());
+            }
+            ThrowItem() => {
+                builder.reborrow().init_throw_item().set_unused(());
+            }
+        }
+    }
+}

--- a/lib/gs_schemas/src/actions.rs
+++ b/lib/gs_schemas/src/actions.rs
@@ -1,6 +1,7 @@
 //! Actions that are generally triggered by clients and handled on the server.
 
 use bevy_math::{IVec3, Vec3};
+
 use crate::actions::ThrowAction::{ThrowBlock, ThrowItem};
 use crate::coordinates::AbsBlockPos;
 use crate::schemas::game_types_capnp::{position_data, throw_action};
@@ -25,7 +26,7 @@ impl TryFrom<position_data::Reader<'_>> for PositionData {
             AbsBlockPos(IVec3 {
                 x: pos.get_x(),
                 y: pos.get_y(),
-                z: pos.get_z()
+                z: pos.get_z(),
             })
         };
         let offset = {
@@ -49,7 +50,6 @@ impl TryFrom<position_data::Reader<'_>> for PositionData {
 }
 
 impl PositionData {
-
     /// writes this position data to the given builder
     pub fn to_builder(self, builder: &mut position_data::Builder<'_>) {
         {
@@ -87,19 +87,14 @@ impl TryFrom<throw_action::Reader<'_>> for ThrowAction {
 
     fn try_from(value: throw_action::Reader) -> Result<Self, Self::Error> {
         match value.reborrow().which() {
-            Ok(throw_action::Which::ThrowItem(_)) => {
-                Ok(ThrowItem())
-            }
-            Ok(throw_action::Which::ThrowBlock(_)) => {
-                Ok(ThrowBlock())
-            }
-            _ => Err(())
+            Ok(throw_action::Which::ThrowItem(_)) => Ok(ThrowItem()),
+            Ok(throw_action::Which::ThrowBlock(_)) => Ok(ThrowBlock()),
+            _ => Err(()),
         }
     }
 }
 
 impl ThrowAction {
-
     /// writes this throw action to the given builder
     pub fn to_builder(self, builder: &mut throw_action::Builder<'_>) {
         match self {

--- a/lib/gs_schemas/src/actions.rs
+++ b/lib/gs_schemas/src/actions.rs
@@ -1,6 +1,6 @@
 //! Actions that are generally triggered by clients and handled on the server.
 
-use bevy_math::{IVec3, Vec3};
+use bevy_math::Vec3;
 
 use crate::actions::ThrowAction::{ThrowBlock, ThrowItem};
 use crate::coordinates::AbsBlockPos;
@@ -15,38 +15,6 @@ pub struct PositionData {
     pub offset: Vec3,
     /// look vector
     pub look: Vec3,
-}
-
-impl TryFrom<position_data::Reader<'_>> for PositionData {
-    type Error = ();
-
-    fn try_from(value: position_data::Reader) -> Result<Self, Self::Error> {
-        let position = {
-            let pos = value.reborrow().get_position().map_err(|_| {})?;
-            AbsBlockPos(IVec3 {
-                x: pos.get_x(),
-                y: pos.get_y(),
-                z: pos.get_z(),
-            })
-        };
-        let offset = {
-            let offset = value.reborrow().get_offset().map_err(|_| {})?;
-            Vec3 {
-                x: offset.get_x(),
-                y: offset.get_y(),
-                z: offset.get_z(),
-            }
-        };
-        let look = {
-            let look = value.reborrow().get_look().map_err(|_| {})?;
-            Vec3 {
-                x: look.get_x(),
-                y: look.get_y(),
-                z: look.get_z(),
-            }
-        };
-        Ok(PositionData { position, offset, look })
-    }
 }
 
 impl PositionData {
@@ -80,18 +48,6 @@ pub enum ThrowAction {
     ThrowBlock(),
     /// Throw an item
     ThrowItem(),
-}
-
-impl TryFrom<throw_action::Reader<'_>> for ThrowAction {
-    type Error = ();
-
-    fn try_from(value: throw_action::Reader) -> Result<Self, Self::Error> {
-        match value.reborrow().which() {
-            Ok(throw_action::Which::ThrowItem(_)) => Ok(ThrowItem()),
-            Ok(throw_action::Which::ThrowBlock(_)) => Ok(ThrowBlock()),
-            _ => Err(()),
-        }
-    }
 }
 
 impl ThrowAction {

--- a/lib/gs_schemas/src/actions.rs
+++ b/lib/gs_schemas/src/actions.rs
@@ -2,9 +2,9 @@
 
 use bevy_math::Vec3;
 
-use crate::actions::ThrowAction::{ThrowBlock, ThrowItem};
+use crate::actions::BlockAction::{BreakBlock, PlaceBlock};
 use crate::coordinates::AbsBlockPos;
-use crate::schemas::game_types_capnp::{position_data, throw_action};
+use crate::schemas::game_types_capnp::{block_action, position_data};
 
 /// Position data
 #[derive(Debug, Copy, Clone)]
@@ -41,24 +41,26 @@ impl PositionData {
     }
 }
 
-/// Throw Action, for world interaction
+/// Block Action, for world interaction by placing or breaking blocks.
+/// For the debug cam era only, should be replaced with a more generalized,
+/// item-driven system once the player is implemented.
 #[derive(Debug, Copy, Clone)]
-pub enum ThrowAction {
-    /// Throw a block
-    ThrowBlock(),
-    /// Throw an item
-    ThrowItem(),
+pub enum BlockAction {
+    /// Place a block
+    PlaceBlock(),
+    /// Break a block
+    BreakBlock(),
 }
 
-impl ThrowAction {
+impl BlockAction {
     /// writes this throw action to the given builder
-    pub fn to_builder(self, builder: &mut throw_action::Builder<'_>) {
+    pub fn to_builder(self, builder: &mut block_action::Builder<'_>) {
         match self {
-            ThrowBlock() => {
-                builder.reborrow().init_throw_block().set_unused(());
+            PlaceBlock() => {
+                builder.reborrow().init_place_block().set_unused(());
             }
-            ThrowItem() => {
-                builder.reborrow().init_throw_item().set_unused(());
+            BreakBlock() => {
+                builder.reborrow().init_break_block().set_unused(());
             }
         }
     }

--- a/lib/gs_schemas/src/actions.rs
+++ b/lib/gs_schemas/src/actions.rs
@@ -21,15 +21,15 @@ impl TryFrom<position_data::Reader<'_>> for PositionData {
 
     fn try_from(value: position_data::Reader) -> Result<Self, Self::Error> {
         let position = {
-            let pos = value.reborrow().get_position().map_err(|_| {()})?;
-            AbsBlockPos { 0: IVec3 {
+            let pos = value.reborrow().get_position().map_err(|_| {})?;
+            AbsBlockPos(IVec3 {
                 x: pos.get_x(),
                 y: pos.get_y(),
                 z: pos.get_z()
-            }}
+            })
         };
         let offset = {
-            let offset = value.reborrow().get_offset().map_err(|_| {()})?;
+            let offset = value.reborrow().get_offset().map_err(|_| {})?;
             Vec3 {
                 x: offset.get_x(),
                 y: offset.get_y(),
@@ -37,7 +37,7 @@ impl TryFrom<position_data::Reader<'_>> for PositionData {
             }
         };
         let look = {
-            let look = value.reborrow().get_look().map_err(|_| {()})?;
+            let look = value.reborrow().get_look().map_err(|_| {})?;
             Vec3 {
                 x: look.get_x(),
                 y: look.get_y(),
@@ -76,7 +76,9 @@ impl PositionData {
 /// Throw Action, for world interaction
 #[derive(Debug, Copy, Clone)]
 pub enum ThrowAction {
+    /// Throw a block
     ThrowBlock(),
+    /// Throw an item
     ThrowItem(),
 }
 

--- a/lib/gs_schemas/src/capnp_adapters.rs
+++ b/lib/gs_schemas/src/capnp_adapters.rs
@@ -4,9 +4,9 @@
 
 use bevy_math::{IVec3, Vec3};
 
-use crate::actions::ThrowAction;
-use crate::actions::ThrowAction::{ThrowBlock, ThrowItem};
-use crate::schemas::game_types_capnp::{i_vec3, throw_action, vec3};
+use crate::actions::BlockAction;
+use crate::actions::BlockAction::{BreakBlock, PlaceBlock};
+use crate::schemas::game_types_capnp::{block_action, i_vec3, vec3};
 
 pub fn adapt_i_vec3(reader: i_vec3::Reader) -> IVec3 {
     IVec3 {
@@ -24,10 +24,10 @@ pub fn adapt_vec3(reader: vec3::Reader) -> Vec3 {
     }
 }
 
-pub fn adapt_throw_action(reader: throw_action::Reader) -> Result<ThrowAction, ()> {
+pub fn adapt_block_action(reader: block_action::Reader) -> Result<BlockAction, ()> {
     match reader.which() {
-        Ok(throw_action::Which::ThrowItem(_)) => Ok(ThrowItem()),
-        Ok(throw_action::Which::ThrowBlock(_)) => Ok(ThrowBlock()),
+        Ok(block_action::Which::BreakBlock(_)) => Ok(BreakBlock()),
+        Ok(block_action::Which::PlaceBlock(_)) => Ok(PlaceBlock()),
         _ => Err(()),
     }
 }

--- a/lib/gs_schemas/src/capnp_adapters.rs
+++ b/lib/gs_schemas/src/capnp_adapters.rs
@@ -1,0 +1,33 @@
+//! Contains conversion implementations for simple capnp readers.
+//! These should only be used if the Rust struct is necessary for passing into a method,
+//! as constructing a rust struct from capnp data removes the main benefit of using capnp.
+
+use bevy_math::{IVec3, Vec3};
+
+use crate::actions::ThrowAction;
+use crate::actions::ThrowAction::{ThrowBlock, ThrowItem};
+use crate::schemas::game_types_capnp::{i_vec3, throw_action, vec3};
+
+pub fn adapt_i_vec3(reader: i_vec3::Reader) -> IVec3 {
+    IVec3 {
+        x: reader.get_x(),
+        y: reader.get_y(),
+        z: reader.get_z(),
+    }
+}
+
+pub fn adapt_vec3(reader: vec3::Reader) -> Vec3 {
+    Vec3 {
+        x: reader.get_x(),
+        y: reader.get_y(),
+        z: reader.get_z(),
+    }
+}
+
+pub fn adapt_throw_action(reader: throw_action::Reader) -> Result<ThrowAction, ()> {
+    match reader.which() {
+        Ok(throw_action::Which::ThrowItem(_)) => Ok(ThrowItem()),
+        Ok(throw_action::Which::ThrowBlock(_)) => Ok(ThrowBlock()),
+        _ => Err(()),
+    }
+}

--- a/lib/gs_schemas/src/coordinates.rs
+++ b/lib/gs_schemas/src/coordinates.rs
@@ -97,6 +97,16 @@ impl WorldPos {
         }
     }
 
+    /// Constructs itself from a given block position at the given offset.
+    #[inline]
+    pub fn from_offset(pos: AbsBlockPos, offset: Vec3A) -> Self {
+        let (cpos, bpos) = pos.split_chunk_component();
+        Self {
+            offset: bpos.as_vec3a() + offset,
+            chunk: cpos,
+        }
+    }
+
     /// Converts any chunk-sized integer part of [`WorldPos::offset`] to the integer [`WorldPos::chunk`] offset to improve precision for further calculations.
     ///
     /// Makes sure that [`WorldPos::offset`] is in the range of `[0, CHUNK_DIMF)`.

--- a/lib/gs_schemas/src/coordinates.rs
+++ b/lib/gs_schemas/src/coordinates.rs
@@ -21,6 +21,8 @@ use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::direction::Direction;
+
 /// Length of a side of a block in meters
 pub const BLOCK_DIM: f32 = 0.5;
 
@@ -99,7 +101,7 @@ impl WorldPos {
 
     /// Constructs itself from a given block position at the given offset.
     #[inline]
-    pub fn from_offset(pos: AbsBlockPos, offset: Vec3A) -> Self {
+    pub fn from_offset_blockpos(pos: AbsBlockPos, offset: Vec3A) -> Self {
         let (cpos, bpos) = pos.split_chunk_component();
         Self {
             offset: bpos.as_vec3a() + offset,
@@ -897,6 +899,14 @@ impl AbsBlockPos {
     #[inline]
     pub fn block_center(self) -> DVec3 {
         self.as_dvec3() + DVec3::splat(0.5)
+    }
+
+    /// Moves the block position in the given direction by the given amount.
+    #[inline]
+    pub fn direction_offset(self, direction: Direction, offset: i32) -> AbsBlockPos {
+        AbsBlockPos {
+            0: self.0 + direction.as_ivec() * offset,
+        }
     }
 }
 

--- a/lib/gs_schemas/src/direction.rs
+++ b/lib/gs_schemas/src/direction.rs
@@ -4,6 +4,8 @@ use std::fmt::Debug;
 use bevy_math::prelude::*;
 use bevy_math::{Mat3A, Vec3A};
 use itertools::Itertools;
+use crate::coordinates::AbsBlockPos;
+use crate::direction::Direction::{XMinus, XPlus, YMinus, YPlus, ZMinus, ZPlus};
 
 /// A direction in the right-handed coordinate system of the game
 #[repr(i32)]
@@ -53,6 +55,19 @@ impl Direction {
             YPlus => YMinus,
             ZMinus => ZPlus,
             ZPlus => ZMinus,
+        }
+    }
+
+    /// offsets the given absolute block pos in this direction by the given amount
+    pub fn offset(&self, pos: &AbsBlockPos, offset: i32) -> AbsBlockPos {
+        let AbsBlockPos { 0: IVec3 { x, y, z} } = pos;
+        match self {
+            XMinus => AbsBlockPos::new(*x - offset, *y, *z),
+            XPlus => AbsBlockPos::new(*x + offset, *y, *z),
+            YMinus => AbsBlockPos::new(*x, *y - offset, *z),
+            YPlus => AbsBlockPos::new(*x, *y + offset, *z),
+            ZMinus => AbsBlockPos::new(*x, *y, *z - offset),
+            ZPlus => AbsBlockPos::new(*x, *y, *z + offset),
         }
     }
 

--- a/lib/gs_schemas/src/direction.rs
+++ b/lib/gs_schemas/src/direction.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use bevy_math::prelude::*;
 use bevy_math::{Mat3A, Vec3A};
 use itertools::Itertools;
+
 use crate::coordinates::AbsBlockPos;
 use crate::direction::Direction::{XMinus, XPlus, YMinus, YPlus, ZMinus, ZPlus};
 
@@ -60,7 +61,7 @@ impl Direction {
 
     /// offsets the given absolute block pos in this direction by the given amount
     pub fn offset(&self, pos: &AbsBlockPos, offset: i32) -> AbsBlockPos {
-        let AbsBlockPos { 0: IVec3 { x, y, z} } = pos;
+        let AbsBlockPos { 0: IVec3 { x, y, z } } = pos;
         match self {
             XMinus => AbsBlockPos::new(*x - offset, *y, *z),
             XPlus => AbsBlockPos::new(*x + offset, *y, *z),

--- a/lib/gs_schemas/src/direction.rs
+++ b/lib/gs_schemas/src/direction.rs
@@ -5,9 +5,6 @@ use bevy_math::prelude::*;
 use bevy_math::{Mat3A, Vec3A};
 use itertools::Itertools;
 
-use crate::coordinates::AbsBlockPos;
-use crate::direction::Direction::{XMinus, XPlus, YMinus, YPlus, ZMinus, ZPlus};
-
 /// A direction in the right-handed coordinate system of the game
 #[repr(i32)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -56,19 +53,6 @@ impl Direction {
             YPlus => YMinus,
             ZMinus => ZPlus,
             ZPlus => ZMinus,
-        }
-    }
-
-    /// offsets the given absolute block pos in this direction by the given amount
-    pub fn offset(&self, pos: &AbsBlockPos, offset: i32) -> AbsBlockPos {
-        let AbsBlockPos { 0: IVec3 { x, y, z } } = pos;
-        match self {
-            XMinus => AbsBlockPos::new(*x - offset, *y, *z),
-            XPlus => AbsBlockPos::new(*x + offset, *y, *z),
-            YMinus => AbsBlockPos::new(*x, *y - offset, *z),
-            YPlus => AbsBlockPos::new(*x, *y + offset, *z),
-            ZMinus => AbsBlockPos::new(*x, *y, *z - offset),
-            ZPlus => AbsBlockPos::new(*x, *y, *z + offset),
         }
     }
 

--- a/lib/gs_schemas/src/lib.rs
+++ b/lib/gs_schemas/src/lib.rs
@@ -12,6 +12,7 @@ extern crate core;
 use smallvec::{Array, SmallVec};
 
 pub mod actions;
+pub mod capnp_adapters;
 pub mod coordinates;
 pub mod direction;
 pub mod math;

--- a/lib/gs_schemas/src/lib.rs
+++ b/lib/gs_schemas/src/lib.rs
@@ -21,6 +21,7 @@ pub mod registries;
 pub mod registry;
 pub mod schemas;
 pub mod voxel;
+pub mod actions;
 
 /// A trait implemented by the game server and client, specifying the concrete types to attach as extra metadata for every chunk, chunk group, entity, etc.
 /// Used to inject side-specific data into common data structures.

--- a/lib/gs_schemas/src/lib.rs
+++ b/lib/gs_schemas/src/lib.rs
@@ -11,6 +11,7 @@ extern crate core;
 
 use smallvec::{Array, SmallVec};
 
+pub mod actions;
 pub mod coordinates;
 pub mod direction;
 pub mod math;
@@ -21,7 +22,6 @@ pub mod registries;
 pub mod registry;
 pub mod schemas;
 pub mod voxel;
-pub mod actions;
 
 /// A trait implemented by the game server and client, specifying the concrete types to attach as extra metadata for every chunk, chunk group, entity, etc.
 /// Used to inject side-specific data into common data structures.

--- a/lib/gs_schemas/src/voxel/chunk_group.rs
+++ b/lib/gs_schemas/src/voxel/chunk_group.rs
@@ -53,4 +53,10 @@ impl<ED: GsExtraData> ChunkGroup<ED> {
     pub fn get_chunk(&self, pos: AbsChunkPos) -> Option<&MutWatcher<Chunk<ED>>> {
         self.chunks.get(&pos)
     }
+
+    /// Accesses the chunk mutably at the given position if loaded.
+    #[inline]
+    pub fn get_chunk_mut(&mut self, pos: AbsChunkPos) -> Option<&mut MutWatcher<Chunk<ED>>> {
+        self.chunks.get_mut(&pos)
+    }
 }


### PR DESCRIPTION
Implements simple block place/break behavior, with prediction on the client and packets sent from client to server for actual world changes.

Notes:
- Rendering implementation was not designed to handle changing chunks, so block removal will not render correctly. Using the debug raytrace view will reveal block removals properly.
- The action of placing and breaking is called throw block / item respectively, because I plan to (in the future) make these actually throwing blocks and throwing items (and certain items will break blocks), see https://discord.com/channels/1137126442950463660/1137127045214777507/1354083221574254674