### PR TITLE
Fix mesh duplication on repeated block placing/breaking

### DIFF
--- a/crates/gs_client/src/debugcam.rs
+++ b/crates/gs_client/src/debugcam.rs
@@ -48,8 +48,8 @@ pub struct KeyBindings {
     pub move_ascend: KeyCode,
     pub move_descend: KeyCode,
     pub toggle_grab_cursor: KeyCode,
-    pub throw_block: MouseButton,
-    pub throw_item: MouseButton,
+    pub place_block: MouseButton,
+    pub break_block: MouseButton,
 }
 
 impl Default for KeyBindings {
@@ -62,8 +62,8 @@ impl Default for KeyBindings {
             move_ascend: KeyCode::Space,
             move_descend: KeyCode::ShiftLeft,
             toggle_grab_cursor: KeyCode::Escape,
-            throw_block: MouseButton::Left,
-            throw_item: MouseButton::Right,
+            place_block: MouseButton::Left,
+            break_block: MouseButton::Right,
         }
     }
 }
@@ -232,11 +232,11 @@ fn player_action(
                 match window.cursor_options.grab_mode {
                     CursorGrabMode::None => (),
                     _ => {
-                        if button == key_bindings.throw_block {
+                        if button == key_bindings.place_block {
                             let pos = transform.translation.floor();
                             let offset = transform.translation - pos;
                             let pos = AbsBlockPos::from_ivec3(pos.as_ivec3());
-                            in_game::ingame_send_throw_packet(
+                            in_game::ingame_send_block_change(
                                 &net_thread,
                                 &mut voxels,
                                 &block_reg,
@@ -247,7 +247,7 @@ fn player_action(
                                 },
                                 BlockAction::PlaceBlock(),
                             );
-                        } else if button == key_bindings.throw_item {
+                        } else if button == key_bindings.break_block {
                             let Vec3 { x, y, z } = transform.translation;
                             let pos = AbsBlockPos::new(x.floor() as i32, y.floor() as i32, z.floor() as i32);
                             let offset = Vec3 {
@@ -255,7 +255,7 @@ fn player_action(
                                 y: y - pos.y as f32,
                                 z: z - pos.z as f32,
                             };
-                            in_game::ingame_send_throw_packet(
+                            in_game::ingame_send_block_change(
                                 &net_thread,
                                 &mut voxels,
                                 &block_reg,

--- a/crates/gs_client/src/states/in_game.rs
+++ b/crates/gs_client/src/states/in_game.rs
@@ -27,8 +27,8 @@ fn ingame_cleanup_on_exit(net_thread: ResMut<ClientNetworkThreadHolder>) {
     net_thread.0.sync_shutdown();
 }
 
-/// sends a throw packet over the given net thread and promise holder
-pub(crate) fn ingame_send_throw_packet(
+/// sends a block modification packet over the given net thread and promise holder
+pub(crate) fn ingame_send_block_change(
     net_thread: &Res<ClientNetworkThreadHolder>,
     voxel_query: &mut Query<&mut ClientVoxelUniverse>,
     block_reg: &Res<BlockRegistryHolder>,

--- a/crates/gs_client/src/voxel/mod.rs
+++ b/crates/gs_client/src/voxel/mod.rs
@@ -31,20 +31,19 @@ pub type ClientChunkGroup = ChunkGroup<ClientData>;
 pub type ClientVoxelUniverse = VoxelUniverse<ClientData>;
 
 /// Keeps track of the render entities associated with a chunk
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 struct ChunkMeshState {
-    meshes: SmallVec<[Handle<Mesh>; 4]>,
     entities: SmallVec<[Entity; 4]>,
 }
 
 /// Client-only per-chunk data storage
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct ClientChunkData {
     mesh: Option<MutWatcher<ChunkMeshState>>,
 }
 
 /// Client-only per-chunk-group data storage
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct ClientChunkGroupData {
     //
 }
@@ -110,12 +109,25 @@ fn handle_chunk_packet(raw_packet: Bytes, voxels: &mut ClientVoxelUniverse) -> R
     let pos = AbsChunkPos::new(cpos_r.get_x(), cpos_r.get_y(), cpos_r.get_z());
     let data_r = root.reborrow().get_data()?;
     let revision: RevisionNumber = root.get_revision().try_into()?;
-    let chunk = ClientChunk::read_full(&data_r, default())?;
 
-    voxels
-        .loaded_chunks_mut()
-        .chunks
-        .insert(pos, MutWatcher::new_saved(chunk, revision));
+    let mut chunk_entry = voxels.loaded_chunks_mut().chunks.entry(pos);
+    let extra_data = if let std::collections::btree_map::Entry::Occupied(ref mut occupied) = chunk_entry {
+        std::mem::take(&mut occupied.get_mut().mutate_without_revision().extra_data)
+    } else {
+        default()
+    };
+    let chunk = ClientChunk::read_full(&data_r, extra_data)?;
+
+    match chunk_entry {
+        std::collections::btree_map::Entry::Occupied(occupied) => {
+            if let Some(e) = occupied.into_mut().mutate_from_server_revision(revision) {
+                *e = chunk;
+            }
+        }
+        std::collections::btree_map::Entry::Vacant(vacant) => {
+            vacant.insert(MutWatcher::new_saved(chunk, revision));
+        }
+    }
 
     Ok(())
 }
@@ -125,7 +137,7 @@ fn client_chunk_mesher_system(
     block_registry: Res<BlockRegistryHolder>,
     mut voxel_material: Local<Option<Handle<ChunkMeshMaterial>>>,
     mut materials: ResMut<Assets<ChunkMeshMaterial>>,
-    mut meshes: ResMut<Assets<Mesh>>,
+    mut mesh_assets: ResMut<Assets<Mesh>>,
     mut commands: Commands,
 ) {
     let Ok(mut voxels) = voxel_q.single_mut() else {
@@ -136,8 +148,13 @@ fn client_chunk_mesher_system(
     let voxel_material = voxel_material.get_or_insert_with(|| materials.add(default_chunk_material()));
 
     // Schedule new meshes for all outdated chunks
-    let mut new_entries = Vec::new();
     let loaded_chunks = voxels.loaded_chunks();
+    enum Mutation {
+        NewMesh(MutWatcher<ChunkMeshState>),
+        NewMeshRevision(MutWatcher<()>),
+    }
+    let mut chunk_mutations: Vec<(AbsChunkPos, Mutation)> = Vec::new();
+
     for (&pos, chunk) in loaded_chunks.chunks.iter() {
         let old_mesh = chunk.extra_data.mesh.as_ref();
         let needs_mesh = if let Some(old_mesh) = old_mesh {
@@ -158,44 +175,40 @@ fn client_chunk_mesher_system(
                 continue;
             }
         };
-        let mesh = meshes.add(chunk_mesh);
-        trace!(position = %pos, "Spawning new chunk mesh");
-
-        let entity = commands
-            .spawn((
-                Mesh3d(mesh.clone()),
-                MeshMaterial3d(voxel_material.clone()),
-                Transform::from_translation(AbsBlockPos::from(pos).as_vec3()),
-            ))
-            .id();
-
-        let mesh = chunk.new_with_same_revision(ChunkMeshState {
-            meshes: smallvec![mesh],
-            entities: smallvec![entity],
-        });
-
-        new_entries.push((pos, mesh));
+        let mesh = mesh_assets.add(chunk_mesh);
+        if let Some(mut old_mesh_entity_commands) = old_mesh.and_then(|om| commands.get_entity(om.entities[0]).ok()) {
+            old_mesh_entity_commands.insert(Mesh3d(mesh));
+            chunk_mutations.push((pos, Mutation::NewMeshRevision(chunk.new_with_same_revision(()))));
+        } else {
+            let entity = commands
+                .spawn((
+                    Mesh3d(mesh),
+                    MeshMaterial3d(voxel_material.clone()),
+                    Transform::from_translation(AbsBlockPos::from(pos).as_vec3()),
+                ))
+                .id();
+            chunk_mutations.push((
+                pos,
+                Mutation::NewMesh(chunk.new_with_same_revision(ChunkMeshState {
+                    entities: smallvec![entity],
+                })),
+            ));
+        }
     }
     let loaded_chunks = voxels.loaded_chunks_mut();
-    for (pos, mesh) in new_entries.into_iter() {
-        let old_mesh = loaded_chunks
-            .chunks
-            .get_mut(&pos)
-            .unwrap()
-            .mutate_without_revision()
-            .extra_data
-            .mesh
-            .replace(mesh);
-        if let Some(old_mesh) = old_mesh {
-            let old_mesh = old_mesh.into_inner();
-            for mesh in old_mesh.meshes.iter() {
-                meshes.remove(mesh);
-            }
-            for &entity in old_mesh.entities.iter() {
-                if let Ok(mut entity) = commands.get_entity(entity) {
-                    entity.despawn();
-                }
-            }
+    for (cpos, mutation) in chunk_mutations {
+        let Some(chunk) = loaded_chunks.get_chunk_mut(cpos) else {
+            unreachable!();
+        };
+        match mutation {
+            Mutation::NewMesh(mesh) => chunk.mutate_without_revision().extra_data.mesh = Some(mesh),
+            Mutation::NewMeshRevision(revision) => chunk
+                .mutate_without_revision()
+                .extra_data
+                .mesh
+                .as_mut()
+                .unwrap()
+                .set_revision_from(&revision),
         }
     }
 }

--- a/crates/gs_common/src/network/server.rs
+++ b/crates/gs_common/src/network/server.rs
@@ -652,8 +652,8 @@ impl rpc::authenticated_server_connection::Server for RcAuthenticatedServer2Clie
         // have to adapt because Readers can't be sent across threads,
         // and schedule_bevy counts as one.
         let action = adapt_block_action(pry!(params.get_action())).unwrap();
-        info!(
-            "Client {} ({:?}) sent a throw packet `{:?}`, `{:?}`",
+        trace!(
+            "Client {} ({:?}) sent a block change packet `{:?}`, `{:?}`",
             self.0.borrow().username,
             self.0.borrow().peer,
             position,

--- a/lib/gs_schemas/src/actions.rs
+++ b/lib/gs_schemas/src/actions.rs
@@ -53,7 +53,7 @@ pub enum BlockAction {
 }
 
 impl BlockAction {
-    /// writes this throw action to the given builder
+    /// writes this block action to the given builder
     pub fn to_builder(self, builder: &mut block_action::Builder<'_>) {
         match self {
             PlaceBlock() => {

--- a/lib/gs_schemas/src/mutwatcher.rs
+++ b/lib/gs_schemas/src/mutwatcher.rs
@@ -60,6 +60,12 @@ impl<T> MutWatcher<T> {
         }
     }
 
+    /// Modifies this [`MutWatcher`] in-place to set the same revision state as another one.
+    pub fn set_revision_from<U>(&mut self, other: &MutWatcher<U>) {
+        self.current_revision = other.current_revision;
+        self.predicted_revision = other.predicted_revision;
+    }
+
     /// Extracts the inner stored value.
     pub fn into_inner(self) -> T {
         self.inner
@@ -148,7 +154,6 @@ impl<T> MutWatcher<T> {
                 self.predicted_revision = Some(self.current_revision.checked_add(1).unwrap());
             }
         }
-        Self::increment(&mut self.current_revision);
         &mut self.inner
     }
 


### PR DESCRIPTION
The core of the issue was `handle_chunk_packet` erasing the client-side chunk data instead of keeping it unmodified, this caused the information about the entity ID of the previous mesh to get lost during packet handling.